### PR TITLE
feat(ci): add Codecov configuration and coverage documentation

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,33 @@
+# Codecov Configuration for gRPCServer.jl
+# Documentation: https://docs.codecov.com/docs/codecov-yaml
+
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "60...100"
+
+  status:
+    project:
+      default:
+        target: 70%
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: 80%
+        threshold: 1%
+        informational: true
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: true
+
+ignore:
+  - "docs/**/*"
+  - "test/**/*"
+  - "examples/**/*"
+  - "specs/**/*"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,6 +48,8 @@ jobs:
       - uses: codecov/codecov-action@v4
         with:
           files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
   docs:
     name: Documentation

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@
 !CONTRIBUTORS.md
 !ROADMAP.md
 !SECURITY.md
+!.codecov.yml
 
 ##############################################
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,91 @@ By participating in this project, you agree to abide by our [Code of Conduct](CO
    Pkg.instantiate(; test=true)
    ```
 
+## Code Coverage
+
+### Viewing Coverage in Codecov
+
+Code coverage is automatically collected and uploaded to Codecov during CI runs. To view coverage:
+
+1. Open a Pull Request - coverage status will appear in PR checks
+2. Click "Details" on the Codecov status check to see the full report
+3. Visit the [Codecov Dashboard](https://codecov.io/gh/s-celles/gRPCServer.jl) to see:
+   - Project-wide coverage percentage
+   - Per-file coverage breakdown
+   - Line-by-line coverage highlighting
+   - Historical coverage trends
+
+### Running Coverage Locally
+
+Run tests with coverage enabled:
+
+```julia
+using Pkg
+Pkg.test("gRPCServer"; coverage=true)
+```
+
+Or from the command line:
+
+```bash
+julia --project -e 'using Pkg; Pkg.test(coverage=true)'
+```
+
+This generates `.cov` files in the `src/` directory.
+
+### Generating Local Coverage Reports
+
+To view coverage locally with detailed reports:
+
+```julia
+using Pkg
+Pkg.test("gRPCServer"; coverage=true)
+
+# Process coverage data
+using Coverage
+coverage = process_folder("src")
+
+# View summary
+covered_lines, total_lines = get_summary(coverage)
+println("Coverage: $(round(covered_lines/total_lines * 100, digits=1))%")
+
+# Generate lcov file (compatible with coverage tools)
+LCOV.writefile("lcov.info", coverage)
+```
+
+To generate an HTML report for browsing locally:
+
+```julia
+using Coverage
+coverage = process_folder("src")
+Coverage.html_report(coverage; dir="coverage_html")
+# Open coverage_html/index.html in your browser
+```
+
+**Note**: For local coverage reports, you may need to add Coverage.jl to your global environment:
+
+```julia
+using Pkg
+Pkg.add("Coverage")
+```
+
+### Coverage Thresholds
+
+The project enforces coverage standards via Codecov:
+
+- **Project coverage target**: 70% (informational, not blocking)
+- **Patch coverage target**: 80% (new code should be well-tested)
+- **Coverage decrease tolerance**: 1% (minor fluctuations allowed)
+
+These thresholds are configured in `.codecov.yml`. PRs will show coverage status checks, but they are informational and won't block merging.
+
+### Codecov Token Setup (Optional)
+
+For repository maintainers: To prevent rate limiting during high CI activity, you can configure a Codecov token:
+
+1. Get the repository token from Codecov settings
+2. Add `CODECOV_TOKEN` as a repository secret in GitHub
+3. Update the CI workflow to pass the token (optional, works without it for public repos)
+
 ## Running Tests
 
 ### All Tests

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/s-celles/gRPCServer.jl)
 [![Build Status](https://github.com/s-celles/gRPCServer.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/s-celles/gRPCServer.jl/actions/workflows/CI.yml)
+[![Coverage](https://codecov.io/gh/s-celles/gRPCServer.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/s-celles/gRPCServer.jl)
 [![Documentation](https://img.shields.io/badge/docs-dev-blue.svg)](https://s-celles.github.io/gRPCServer.jl/dev)
 
 A native Julia implementation of a [gRPC](https://grpc.io/) server library.


### PR DESCRIPTION
## Summary

- Add `.codecov.yml` with coverage thresholds (70% project, 80% patch)
- Configure PR comments and informational status checks
- Add coverage badge to README.md
- Document coverage workflow in CONTRIBUTING.md

## Changes

### New Files
- **`.codecov.yml`**: Codecov configuration with:
  - Project coverage target: 70%
  - Patch coverage target: 80%
  - Informational status checks (non-blocking)
  - PR comment layout configuration
  - Ignore patterns for docs, tests, examples, specs

### Modified Files
- **`.gitignore`**: Added `.codecov.yml` to allowlist
- **`README.md`**: Added Codecov coverage badge
- **`CONTRIBUTING.md`**: Added comprehensive "Code Coverage" section with:
  - How to view coverage in Codecov dashboard
  - Running coverage locally
  - Generating HTML coverage reports
  - Coverage threshold explanation
  - Optional Codecov token setup instructions

## Test Plan

- [x] All tests pass (1323/1323)
- [ ] Verify Codecov status check appears on this PR
- [ ] Verify PR comment from Codecov appears
- [ ] Verify coverage badge displays on README after merge

## Related

Implements feature specification from `specs/006-code-coverage/`