### PR TITLE
test: add gRPC HTTP/2 protocol conformance tests

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -53,6 +53,9 @@ ServiceAlreadyRegisteredError
 InvalidServerStateError
 MethodSignatureError
 StreamCancelledError
+status_code_to_http
+exception_to_status_code
+http2_to_grpc_status
 ```
 
 ## Interceptors

--- a/src/compression.jl
+++ b/src/compression.jl
@@ -39,12 +39,12 @@ function codec_name(codec::CompressionCodec.T)::String
 end
 
 """
-    parse_codec(name::String) -> Union{CompressionCodec.T, Nothing}
+    parse_codec(name::AbstractString) -> Union{CompressionCodec.T, Nothing}
 
 Parse a gRPC encoding name to a compression codec.
 Returns `nothing` if the encoding is not supported.
 """
-function parse_codec(name::String)::Union{CompressionCodec.T, Nothing}
+function parse_codec(name::AbstractString)::Union{CompressionCodec.T, Nothing}
     name = lowercase(strip(name))
     if name == "identity" || name == ""
         CompressionCodec.IDENTITY

--- a/src/gRPCServer.jl
+++ b/src/gRPCServer.jl
@@ -95,6 +95,7 @@ export ServerStatus, StatusCode, MethodType, HealthStatus, CompressionCodec
 # Error Types
 export GRPCError, BindError, ServiceAlreadyRegisteredError
 export InvalidServerStateError, MethodSignatureError, StreamCancelledError
+export status_code_to_http, exception_to_status_code, http2_to_grpc_status
 
 # Stream Types
 export ServerStream, ClientStream, BidiStream

--- a/test/TestUtils.jl
+++ b/test/TestUtils.jl
@@ -10,6 +10,9 @@ export MockGRPCClient, connect!, disconnect!, is_connected
 export send_preface!, build_grpc_message, parse_grpc_message
 export TestServer, create_test_server, start_test_server!, stop_test_server!
 export with_test_server
+export MockHTTP2Request, create_mock_stream, create_mock_headers
+export build_headers_frame_payload, build_data_frame
+export validate_grpc_request_headers, validate_grpc_response
 
 """
     MockGRPCClient
@@ -207,6 +210,280 @@ function with_test_server(f::Function; kwargs...)
         end
     finally
         stop_test_server!(ts)
+    end
+end
+
+# =============================================================================
+# Mock HTTP/2 Request Utilities for Conformance Testing
+# =============================================================================
+
+"""
+    MockHTTP2Request
+
+A mock HTTP/2 request for testing gRPC protocol conformance.
+"""
+struct MockHTTP2Request
+    method::String
+    path::String
+    authority::String
+    scheme::String
+    content_type::Union{String, Nothing}
+    te::Union{String, Nothing}
+    grpc_timeout::Union{String, Nothing}
+    grpc_encoding::Union{String, Nothing}
+    metadata::Dict{String, String}
+    body::Vector{UInt8}
+end
+
+function MockHTTP2Request(;
+    method::String="POST",
+    path::String="/pkg.Service/Method",
+    authority::String="localhost:50051",
+    scheme::String="http",
+    content_type::Union{String, Nothing}="application/grpc",
+    te::Union{String, Nothing}="trailers",
+    grpc_timeout::Union{String, Nothing}=nothing,
+    grpc_encoding::Union{String, Nothing}=nothing,
+    metadata::Dict{String, String}=Dict{String, String}(),
+    body::Vector{UInt8}=UInt8[]
+)
+    return MockHTTP2Request(method, path, authority, scheme, content_type,
+                            te, grpc_timeout, grpc_encoding, metadata, body)
+end
+
+"""
+    create_mock_headers(request::MockHTTP2Request) -> Vector{Tuple{String, String}}
+
+Create HTTP/2 headers from a mock request.
+"""
+function create_mock_headers(request::MockHTTP2Request)::Vector{Tuple{String, String}}
+    headers = Tuple{String, String}[
+        (":method", request.method),
+        (":path", request.path),
+        (":scheme", request.scheme),
+        (":authority", request.authority),
+    ]
+
+    if request.content_type !== nothing
+        push!(headers, ("content-type", request.content_type))
+    end
+
+    if request.te !== nothing
+        push!(headers, ("te", request.te))
+    end
+
+    if request.grpc_timeout !== nothing
+        push!(headers, ("grpc-timeout", request.grpc_timeout))
+    end
+
+    if request.grpc_encoding !== nothing
+        push!(headers, ("grpc-encoding", request.grpc_encoding))
+    end
+
+    for (key, value) in request.metadata
+        push!(headers, (key, value))
+    end
+
+    return headers
+end
+
+"""
+    create_mock_stream(request::MockHTTP2Request; stream_id::UInt32=UInt32(1)) -> HTTP2Stream
+
+Create a mock HTTP2Stream from a mock request for testing.
+"""
+function create_mock_stream(request::MockHTTP2Request; stream_id::UInt32=UInt32(1))
+    stream = gRPCServer.HTTP2Stream(stream_id)
+    stream.request_headers = create_mock_headers(request)
+    stream.headers_complete = true
+
+    if !isempty(request.body)
+        write(stream.data_buffer, request.body)
+    end
+
+    # Set stream state to OPEN (simulating headers received)
+    stream.state = gRPCServer.StreamState.OPEN
+
+    return stream
+end
+
+"""
+    validate_grpc_request_headers(headers::Vector{Tuple{String, String}}) -> Tuple{Bool, String}
+
+Validate gRPC request headers according to protocol spec.
+Returns (is_valid, error_message).
+"""
+function validate_grpc_request_headers(headers::Vector{Tuple{String, String}})::Tuple{Bool, String}
+    headers_dict = Dict{String, String}()
+    for (name, value) in headers
+        headers_dict[lowercase(name)] = value
+    end
+
+    # Check required pseudo-headers
+    method = get(headers_dict, ":method", nothing)
+    if method === nothing
+        return (false, "Missing :method pseudo-header")
+    end
+    if method != "POST"
+        return (false, "Method must be POST, got: $method")
+    end
+
+    path = get(headers_dict, ":path", nothing)
+    if path === nothing
+        return (false, "Missing :path pseudo-header")
+    end
+    if !startswith(path, "/") || count('/', path) < 2
+        return (false, "Invalid path format: $path")
+    end
+
+    # Check content-type
+    content_type = get(headers_dict, "content-type", nothing)
+    if content_type === nothing
+        return (false, "Missing content-type header")
+    end
+    if !startswith(lowercase(content_type), "application/grpc")
+        return (false, "Invalid content-type: $content_type")
+    end
+
+    return (true, "")
+end
+
+"""
+    validate_grpc_response(
+        status::Int,
+        content_type::Union{String, Nothing},
+        grpc_status::Union{Int, Nothing},
+        has_trailers::Bool
+    ) -> Tuple{Bool, String}
+
+Validate gRPC response according to protocol spec.
+Returns (is_valid, error_message).
+"""
+function validate_grpc_response(;
+    status::Int=200,
+    content_type::Union{String, Nothing}=nothing,
+    grpc_status::Union{Int, Nothing}=nothing,
+    has_trailers::Bool=false
+)::Tuple{Bool, String}
+    # HTTP status must be 200
+    if status != 200
+        return (false, "HTTP status must be 200, got: $status")
+    end
+
+    # Content-type must be application/grpc
+    if content_type !== nothing && !startswith(lowercase(content_type), "application/grpc")
+        return (false, "Invalid content-type: $content_type")
+    end
+
+    # grpc-status must be present in trailers
+    if grpc_status === nothing && !has_trailers
+        return (false, "Missing grpc-status in trailers")
+    end
+
+    # grpc-status must be valid (0-16)
+    if grpc_status !== nothing && (grpc_status < 0 || grpc_status > 16)
+        return (false, "Invalid grpc-status: $grpc_status")
+    end
+
+    return (true, "")
+end
+
+"""
+    build_headers_frame_payload(headers::Vector{Tuple{String, String}}) -> Vector{UInt8}
+
+Build a simple HPACK-encoded headers payload for testing.
+Uses literal header field without indexing for simplicity.
+"""
+function build_headers_frame_payload(headers::Vector{Tuple{String, String}})::Vector{UInt8}
+    result = UInt8[]
+
+    for (name, value) in headers
+        # Literal Header Field without Indexing (RFC 7541 Section 6.2.2)
+        # First byte: 0000xxxx where xxxx is the name length (with huffman bit = 0)
+        push!(result, 0x00)  # Literal without indexing, new name
+
+        # Name length (7-bit prefix)
+        name_bytes = Vector{UInt8}(name)
+        push!(result, UInt8(length(name_bytes)))
+        append!(result, name_bytes)
+
+        # Value length (7-bit prefix)
+        value_bytes = Vector{UInt8}(value)
+        push!(result, UInt8(length(value_bytes)))
+        append!(result, value_bytes)
+    end
+
+    return result
+end
+
+"""
+    build_data_frame(data::Vector{UInt8}; end_stream::Bool=false) -> Vector{UInt8}
+
+Build an HTTP/2 DATA frame (without the 9-byte header).
+"""
+function build_data_frame(data::Vector{UInt8}; end_stream::Bool=false)::Vector{UInt8}
+    # This returns just the payload; the frame header is added by the caller
+    return copy(data)
+end
+
+"""
+    MockResponseCollector
+
+Collects response frames for testing.
+"""
+mutable struct MockResponseCollector
+    headers::Vector{Tuple{String, String}}
+    data::Vector{UInt8}
+    trailers::Vector{Tuple{String, String}}
+    http_status::Union{Int, Nothing}
+    grpc_status::Union{Int, Nothing}
+    grpc_message::Union{String, Nothing}
+end
+
+function MockResponseCollector()
+    return MockResponseCollector(
+        Tuple{String, String}[],
+        UInt8[],
+        Tuple{String, String}[],
+        nothing,
+        nothing,
+        nothing
+    )
+end
+
+"""
+    parse_response_headers!(collector::MockResponseCollector, headers::Vector{Tuple{String, String}})
+
+Parse response headers into the collector.
+"""
+function parse_response_headers!(collector::MockResponseCollector, headers::Vector{Tuple{String, String}})
+    for (name, value) in headers
+        name_lower = lowercase(name)
+        if name_lower == ":status"
+            collector.http_status = parse(Int, value)
+        elseif name_lower == "grpc-status"
+            collector.grpc_status = parse(Int, value)
+        elseif name_lower == "grpc-message"
+            collector.grpc_message = value
+        end
+        push!(collector.headers, (name, value))
+    end
+end
+
+"""
+    parse_response_trailers!(collector::MockResponseCollector, trailers::Vector{Tuple{String, String}})
+
+Parse response trailers into the collector.
+"""
+function parse_response_trailers!(collector::MockResponseCollector, trailers::Vector{Tuple{String, String}})
+    for (name, value) in trailers
+        name_lower = lowercase(name)
+        if name_lower == "grpc-status"
+            collector.grpc_status = parse(Int, value)
+        elseif name_lower == "grpc-message"
+            collector.grpc_message = value
+        end
+        push!(collector.trailers, (name, value))
     end
 end
 

--- a/test/fixtures/conformance_data.jl
+++ b/test/fixtures/conformance_data.jl
@@ -1,0 +1,279 @@
+# Conformance test data constants for gRPC HTTP/2 protocol conformance testing
+# Reference: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
+
+"""
+Test data constants for gRPC HTTP/2 protocol conformance testing.
+"""
+module ConformanceData
+
+export TIMEOUT_TEST_CASES, ERROR_MAPPING_TEST_CASES, CONTENT_TYPE_TEST_CASES
+export MESSAGE_FRAME_TEST_CASES, VALID_METHODS, INVALID_METHODS
+export VALID_PATHS, INVALID_PATHS, HTTP2_ERROR_CODES
+
+# =============================================================================
+# Timeout Parsing Test Data
+# =============================================================================
+
+"""
+Timeout test cases: (input, expected_ms, should_fail)
+- input: timeout string (e.g., "1S", "500m")
+- expected_ms: expected milliseconds (nothing if invalid)
+- should_fail: whether parsing should fail
+"""
+const TIMEOUT_TEST_CASES = [
+    # Valid timeouts
+    ("1H", 3600000, false),      # 1 hour
+    ("30M", 1800000, false),     # 30 minutes
+    ("60S", 60000, false),       # 60 seconds
+    ("500m", 500, false),        # 500 milliseconds
+    ("1000u", 1, false),         # 1000 microseconds = 1ms (rounded)
+    ("1000000n", 1, false),      # 1000000 nanoseconds = 1ms (rounded)
+    ("0S", 0, false),            # Zero timeout
+    ("100S", 100000, false),     # 100 seconds
+    ("1m", 1, false),            # 1 millisecond
+    ("10H", 36000000, false),    # 10 hours
+
+    # Invalid timeouts
+    ("", nothing, true),         # Empty
+    ("1", nothing, true),        # Missing unit
+    ("S", nothing, true),        # Missing value
+    ("-1S", nothing, true),      # Negative
+    ("1X", nothing, true),       # Invalid unit
+    ("abc", nothing, true),      # Non-numeric
+    ("1.5S", nothing, true),     # Float value (gRPC uses integers)
+]
+
+# =============================================================================
+# HTTP/2 to gRPC Error Code Mapping Test Data
+# =============================================================================
+
+"""
+HTTP/2 error codes per RFC 7540 Section 7.
+"""
+const HTTP2_ERROR_CODES = Dict{UInt32, String}(
+    0x00 => "NO_ERROR",
+    0x01 => "PROTOCOL_ERROR",
+    0x02 => "INTERNAL_ERROR",
+    0x03 => "FLOW_CONTROL_ERROR",
+    0x04 => "SETTINGS_TIMEOUT",
+    0x05 => "STREAM_CLOSED",
+    0x06 => "FRAME_SIZE_ERROR",
+    0x07 => "REFUSED_STREAM",
+    0x08 => "CANCEL",
+    0x09 => "COMPRESSION_ERROR",
+    0x0A => "CONNECT_ERROR",
+    0x0B => "ENHANCE_YOUR_CALM",
+    0x0C => "INADEQUATE_SECURITY",
+    0x0D => "HTTP_1_1_REQUIRED",
+)
+
+"""
+Error mapping test cases: (http2_error, http2_name, expected_grpc_status)
+Mapping per gRPC HTTP/2 Protocol spec.
+"""
+const ERROR_MAPPING_TEST_CASES = [
+    (0x00, "NO_ERROR", 13),           # INTERNAL
+    (0x01, "PROTOCOL_ERROR", 13),     # INTERNAL
+    (0x02, "INTERNAL_ERROR", 13),     # INTERNAL
+    (0x03, "FLOW_CONTROL_ERROR", 13), # INTERNAL
+    (0x04, "SETTINGS_TIMEOUT", 13),   # INTERNAL
+    (0x05, "STREAM_CLOSED", 13),      # INTERNAL
+    (0x06, "FRAME_SIZE_ERROR", 13),   # INTERNAL
+    (0x07, "REFUSED_STREAM", 14),     # UNAVAILABLE
+    (0x08, "CANCEL", 1),              # CANCELLED
+    (0x09, "COMPRESSION_ERROR", 13),  # INTERNAL
+    (0x0A, "CONNECT_ERROR", 13),      # INTERNAL
+    (0x0B, "ENHANCE_YOUR_CALM", 8),   # RESOURCE_EXHAUSTED
+    (0x0C, "INADEQUATE_SECURITY", 7), # PERMISSION_DENIED
+    (0x0D, "HTTP_1_1_REQUIRED", 13),  # INTERNAL (not in spec, default)
+]
+
+# =============================================================================
+# Content-Type Validation Test Data
+# =============================================================================
+
+"""
+Content-type test cases: (input, is_valid, normalized_type)
+"""
+const CONTENT_TYPE_TEST_CASES = [
+    # Valid content-types
+    ("application/grpc", true, "application/grpc"),
+    ("application/grpc+proto", true, "application/grpc+proto"),
+    ("application/grpc+json", true, "application/grpc+json"),
+    ("application/grpc; charset=utf-8", true, "application/grpc"),
+    ("application/grpc+proto; charset=utf-8", true, "application/grpc+proto"),
+    ("APPLICATION/GRPC", true, "APPLICATION/GRPC"),  # Case insensitive prefix check
+
+    # Invalid content-types
+    ("application/json", false, nothing),
+    ("text/plain", false, nothing),
+    ("application/protobuf", false, nothing),
+    ("", false, nothing),
+    ("grpc", false, nothing),
+    ("application/grp", false, nothing),  # Missing 'c'
+]
+
+# =============================================================================
+# Message Framing Test Data
+# =============================================================================
+
+"""
+Message frame test cases: (input_bytes, expected_compressed, expected_length, expected_message, should_fail)
+Format: 1 byte compressed flag + 4 bytes length (big-endian) + message
+"""
+const MESSAGE_FRAME_TEST_CASES = [
+    # Valid frames - uncompressed
+    (
+        UInt8[0x00, 0x00, 0x00, 0x00, 0x05, 0x01, 0x02, 0x03, 0x04, 0x05],
+        0x00,           # Not compressed
+        5,              # Length
+        UInt8[0x01, 0x02, 0x03, 0x04, 0x05],
+        false           # Should not fail
+    ),
+    # Valid frames - compressed flag set
+    (
+        UInt8[0x01, 0x00, 0x00, 0x00, 0x03, 0xAA, 0xBB, 0xCC],
+        0x01,           # Compressed
+        3,              # Length
+        UInt8[0xAA, 0xBB, 0xCC],
+        false
+    ),
+    # Empty message
+    (
+        UInt8[0x00, 0x00, 0x00, 0x00, 0x00],
+        0x00,
+        0,
+        UInt8[],
+        false
+    ),
+    # Large length field (256 bytes)
+    (
+        vcat(UInt8[0x00, 0x00, 0x00, 0x01, 0x00], zeros(UInt8, 256)),
+        0x00,
+        256,
+        zeros(UInt8, 256),
+        false
+    ),
+
+    # Invalid frames
+    (
+        UInt8[0x00, 0x00, 0x00],  # Too short (only 3 bytes, need 5 for header)
+        0x00, 0, UInt8[], true
+    ),
+    (
+        UInt8[0x00, 0x00, 0x00, 0x00, 0x05, 0x01, 0x02],  # Truncated message
+        0x00, 5, UInt8[], true
+    ),
+]
+
+# =============================================================================
+# HTTP Method Validation Test Data
+# =============================================================================
+
+"""
+Valid HTTP methods for gRPC (only POST is allowed)
+"""
+const VALID_METHODS = ["POST"]
+
+"""
+Invalid HTTP methods for gRPC
+"""
+const INVALID_METHODS = [
+    "GET",
+    "PUT",
+    "DELETE",
+    "PATCH",
+    "HEAD",
+    "OPTIONS",
+    "CONNECT",
+    "TRACE",
+]
+
+# =============================================================================
+# Path Validation Test Data
+# =============================================================================
+
+"""
+Valid gRPC path formats: /{service}/{method}
+"""
+const VALID_PATHS = [
+    "/helloworld.Greeter/SayHello",
+    "/grpc.health.v1.Health/Check",
+    "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
+    "/pkg.Service/Method",
+    "/a/b",  # Minimal valid path
+]
+
+"""
+Invalid gRPC path formats
+Note: gRPC spec is lenient - path must start with "/" and have at least one segment
+"""
+const INVALID_PATHS = [
+    "",                    # Empty
+    "/",                   # No service/method (only one slash)
+    "/service",            # Missing method (only one segment - actually has only 1 slash)
+    "service/method",      # Missing leading slash
+]
+
+# =============================================================================
+# TE Header Test Data
+# =============================================================================
+
+"""
+Valid TE header values
+"""
+const VALID_TE_HEADERS = ["trailers"]
+
+"""
+Invalid/missing TE header scenarios
+"""
+const INVALID_TE_HEADERS = [
+    "",           # Empty
+    "chunked",    # Wrong value
+    "gzip",       # Wrong value
+    nothing,      # Missing header (represented as nothing)
+]
+
+# =============================================================================
+# Binary Metadata Test Data
+# =============================================================================
+
+"""
+Binary metadata test cases: (header_name, raw_value, is_binary, expected_decoded)
+Binary headers must have "-bin" suffix and are base64 encoded.
+"""
+const BINARY_METADATA_TEST_CASES = [
+    ("x-custom-bin", "AQIDBA==", true, UInt8[0x01, 0x02, 0x03, 0x04]),
+    ("x-trace-bin", "dGVzdA==", true, UInt8[0x74, 0x65, 0x73, 0x74]),  # "test"
+    ("x-custom", "plain-text", false, "plain-text"),
+    ("authorization", "Bearer token123", false, "Bearer token123"),
+]
+
+# =============================================================================
+# gRPC Status Codes
+# =============================================================================
+
+"""
+gRPC status codes per specification.
+"""
+const GRPC_STATUS_CODES = Dict{Int, String}(
+    0 => "OK",
+    1 => "CANCELLED",
+    2 => "UNKNOWN",
+    3 => "INVALID_ARGUMENT",
+    4 => "DEADLINE_EXCEEDED",
+    5 => "NOT_FOUND",
+    6 => "ALREADY_EXISTS",
+    7 => "PERMISSION_DENIED",
+    8 => "RESOURCE_EXHAUSTED",
+    9 => "FAILED_PRECONDITION",
+    10 => "ABORTED",
+    11 => "OUT_OF_RANGE",
+    12 => "UNIMPLEMENTED",
+    13 => "INTERNAL",
+    14 => "UNAVAILABLE",
+    15 => "DATA_LOSS",
+    16 => "UNAUTHENTICATED",
+)
+
+end # module ConformanceData

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,15 @@ using .TestUtils
     include("unit/test_http2_stream.jl")
     include("unit/test_stream_state_validation.jl")
     include("unit/test_content_type.jl")
+    include("unit/test_grpc_protocol.jl")
+    include("unit/test_http2_conformance.jl")
+    include("unit/test_request_validation.jl")
+    include("unit/test_response_format.jl")
+    include("unit/test_message_encoding.jl")
+    include("unit/test_custom_metadata.jl")
+    include("unit/test_error_mapping.jl")
+    include("unit/test_connection_management.jl")
+    include("unit/test_timeout_handling.jl")
 
     # Integration tests
     include("integration/test_unary.jl")

--- a/test/unit/test_connection_management.jl
+++ b/test/unit/test_connection_management.jl
@@ -1,0 +1,244 @@
+# AC6: Connection Management Tests
+# Tests per RFC 7540 and gRPC HTTP/2 Protocol Specification
+
+using Test
+using gRPCServer
+
+# Include conformance test data
+include("../fixtures/conformance_data.jl")
+using .ConformanceData
+
+@testset "AC6: Connection Management" begin
+
+    # =========================================================================
+    # T037: Connection Preface
+    # =========================================================================
+
+    @testset "T037: Connection preface" begin
+
+        @testset "Connection preface constant" begin
+            @test gRPCServer.CONNECTION_PREFACE == b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+            @test length(gRPCServer.CONNECTION_PREFACE) == 24
+        end
+
+        @testset "Connection starts in PREFACE state" begin
+            conn = gRPCServer.HTTP2Connection()
+            @test conn.state == gRPCServer.ConnectionState.PREFACE
+        end
+
+        @testset "Valid preface transitions to OPEN" begin
+            conn = gRPCServer.HTTP2Connection()
+            preface = Vector{UInt8}(gRPCServer.CONNECTION_PREFACE)
+            success, frames = gRPCServer.process_preface(conn, preface)
+
+            @test success
+            @test conn.state == gRPCServer.ConnectionState.OPEN
+        end
+
+        @testset "Invalid preface throws error" begin
+            conn = gRPCServer.HTTP2Connection()
+            # Same length but wrong content
+            invalid = Vector{UInt8}("PRI * HTTP/1.1\r\n\r\nSM\r\n\r\n")
+            @test_throws gRPCServer.ConnectionError gRPCServer.process_preface(conn, invalid)
+        end
+
+        @testset "Short preface returns false (needs more data)" begin
+            conn = gRPCServer.HTTP2Connection()
+            short = Vector{UInt8}("PRI * HTTP")
+            success, _ = gRPCServer.process_preface(conn, short)
+            @test !success
+            @test conn.state == gRPCServer.ConnectionState.PREFACE
+        end
+
+    end  # T037
+
+    # =========================================================================
+    # T038: PING Frame Handling
+    # =========================================================================
+
+    @testset "T038: PING frame handling" begin
+
+        @testset "PING frame on stream 0" begin
+            ping = gRPCServer.ping_frame(zeros(UInt8, 8))
+            @test ping.header.stream_id == 0
+        end
+
+        @testset "PING payload is 8 bytes" begin
+            ping = gRPCServer.ping_frame(UInt8[1,2,3,4,5,6,7,8])
+            @test ping.header.length == 8
+        end
+
+        @testset "PING ACK has same payload" begin
+            opaque_data = UInt8[0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE]
+            conn = gRPCServer.HTTP2Connection()
+            conn.state = gRPCServer.ConnectionState.OPEN
+
+            ping = gRPCServer.ping_frame(opaque_data)
+            responses = gRPCServer.process_ping_frame!(conn, ping)
+
+            @test length(responses) == 1
+            ack = responses[1]
+            @test gRPCServer.has_flag(ack.header, gRPCServer.FrameFlags.ACK)
+            @test ack.payload == opaque_data
+        end
+
+        @testset "PING ACK is not re-acknowledged" begin
+            conn = gRPCServer.HTTP2Connection()
+            conn.state = gRPCServer.ConnectionState.OPEN
+
+            ping_ack = gRPCServer.ping_frame(zeros(UInt8, 8); ack=true)
+            responses = gRPCServer.process_ping_frame!(conn, ping_ack)
+
+            @test isempty(responses)
+        end
+
+    end  # T038
+
+    # =========================================================================
+    # T039: GOAWAY Frame Handling
+    # =========================================================================
+
+    @testset "T039: GOAWAY frame handling" begin
+
+        @testset "GOAWAY on stream 0" begin
+            goaway = gRPCServer.goaway_frame(10, gRPCServer.ErrorCode.NO_ERROR)
+            @test goaway.header.stream_id == 0
+        end
+
+        @testset "GOAWAY with NO_ERROR → CLOSING" begin
+            conn = gRPCServer.HTTP2Connection()
+            conn.state = gRPCServer.ConnectionState.OPEN
+            conn.last_client_stream_id = UInt32(5)
+
+            gRPCServer.send_goaway(conn, gRPCServer.ErrorCode.NO_ERROR)
+
+            @test conn.goaway_sent
+            @test conn.state == gRPCServer.ConnectionState.CLOSING
+        end
+
+        @testset "GOAWAY with error → CLOSED" begin
+            conn = gRPCServer.HTTP2Connection()
+            conn.state = gRPCServer.ConnectionState.OPEN
+
+            gRPCServer.send_goaway(conn, gRPCServer.ErrorCode.PROTOCOL_ERROR)
+
+            @test conn.goaway_sent
+            @test conn.state == gRPCServer.ConnectionState.CLOSED
+        end
+
+        @testset "GOAWAY includes last stream ID" begin
+            conn = gRPCServer.HTTP2Connection()
+            conn.state = gRPCServer.ConnectionState.OPEN
+            conn.last_client_stream_id = UInt32(7)
+
+            goaway = gRPCServer.send_goaway(conn, gRPCServer.ErrorCode.NO_ERROR)
+            last_stream, error_code, _ = gRPCServer.parse_goaway_frame(goaway)
+
+            @test last_stream == 7
+            @test error_code == gRPCServer.ErrorCode.NO_ERROR
+        end
+
+        @testset "GOAWAY with debug data" begin
+            debug = Vector{UInt8}("Connection timeout")
+            goaway = gRPCServer.goaway_frame(0, gRPCServer.ErrorCode.CANCEL, debug)
+            _, _, parsed_debug = gRPCServer.parse_goaway_frame(goaway)
+
+            @test String(parsed_debug) == "Connection timeout"
+        end
+
+    end  # T039
+
+    # =========================================================================
+    # T040: Flow Control
+    # =========================================================================
+
+    @testset "T040: Flow control" begin
+
+        @testset "Initial window size" begin
+            @test gRPCServer.DEFAULT_INITIAL_WINDOW_SIZE == 65535
+        end
+
+        @testset "WINDOW_UPDATE increment validation" begin
+            # Valid: 1 to 2^31-1
+            @test_nowarn gRPCServer.window_update_frame(0, 1)
+            @test_nowarn gRPCServer.window_update_frame(0, 2147483647)
+
+            # Invalid: 0
+            @test_throws ArgumentError gRPCServer.window_update_frame(0, 0)
+        end
+
+        @testset "WINDOW_UPDATE on connection level" begin
+            frame = gRPCServer.window_update_frame(0, 65535)
+            @test frame.header.stream_id == 0
+        end
+
+        @testset "WINDOW_UPDATE on stream level" begin
+            frame = gRPCServer.window_update_frame(5, 32768)
+            @test frame.header.stream_id == 5
+        end
+
+        @testset "WINDOW_UPDATE frame size" begin
+            frame = gRPCServer.window_update_frame(0, 65535)
+            @test frame.header.length == 4
+        end
+
+    end  # T040
+
+    # =========================================================================
+    # T041: Stream Management
+    # =========================================================================
+
+    @testset "T041: Stream management" begin
+
+        @testset "Client-initiated streams are odd" begin
+            @test gRPCServer.is_client_initiated(1)
+            @test gRPCServer.is_client_initiated(3)
+            @test gRPCServer.is_client_initiated(5)
+            @test !gRPCServer.is_client_initiated(2)
+            @test !gRPCServer.is_client_initiated(4)
+        end
+
+        @testset "Server-initiated streams are even" begin
+            @test gRPCServer.is_server_initiated(2)
+            @test gRPCServer.is_server_initiated(4)
+            @test !gRPCServer.is_server_initiated(1)
+            @test !gRPCServer.is_server_initiated(0)
+        end
+
+        @testset "Stream creation" begin
+            conn = gRPCServer.HTTP2Connection()
+            conn.state = gRPCServer.ConnectionState.OPEN
+
+            stream = gRPCServer.create_stream(conn, UInt32(1))
+            @test stream.id == 1
+            @test stream.state == gRPCServer.StreamState.IDLE
+        end
+
+        @testset "Stream state transitions" begin
+            stream = gRPCServer.HTTP2Stream(UInt32(1))
+            @test stream.state == gRPCServer.StreamState.IDLE
+
+            gRPCServer.receive_headers!(stream, false)
+            @test stream.state == gRPCServer.StreamState.OPEN
+
+            gRPCServer.send_headers!(stream, true)
+            @test stream.state == gRPCServer.StreamState.HALF_CLOSED_LOCAL
+        end
+
+        @testset "RST_STREAM closes stream" begin
+            stream = gRPCServer.HTTP2Stream(UInt32(1))
+            stream.state = gRPCServer.StreamState.OPEN
+
+            gRPCServer.receive_rst_stream!(stream, UInt32(gRPCServer.ErrorCode.CANCEL))
+            @test gRPCServer.is_closed(stream)
+            @test stream.reset
+        end
+
+        @testset "Concurrent streams limit" begin
+            conn = gRPCServer.HTTP2Connection()
+            @test conn.local_settings.max_concurrent_streams == 100
+        end
+
+    end  # T041
+
+end  # AC6: Connection Management

--- a/test/unit/test_custom_metadata.jl
+++ b/test/unit/test_custom_metadata.jl
@@ -1,0 +1,274 @@
+# AC4: Custom Metadata Tests
+# Tests per gRPC HTTP/2 Protocol Specification
+# Reference: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
+
+using Test
+using Base64
+using gRPCServer
+
+# Include conformance test data
+include("../fixtures/conformance_data.jl")
+using .ConformanceData
+
+@testset "AC4: Custom Metadata" begin
+
+    # =========================================================================
+    # T027: ASCII Metadata Headers
+    # =========================================================================
+
+    @testset "T027: ASCII metadata headers" begin
+
+        @testset "Custom string metadata preserved" begin
+            request = TestUtils.MockHTTP2Request(
+                metadata=Dict(
+                    "x-custom-header" => "custom-value",
+                    "x-another" => "another-value"
+                )
+            )
+            stream = TestUtils.create_mock_stream(request)
+            metadata = gRPCServer.get_metadata(stream)
+
+            found_custom = false
+            found_another = false
+            for (name, value) in metadata
+                if name == "x-custom-header"
+                    @test value == "custom-value"
+                    found_custom = true
+                elseif name == "x-another"
+                    @test value == "another-value"
+                    found_another = true
+                end
+            end
+            @test found_custom
+            @test found_another
+        end
+
+        @testset "Authorization header preserved" begin
+            request = TestUtils.MockHTTP2Request(
+                metadata=Dict("authorization" => "Bearer token123")
+            )
+            stream = TestUtils.create_mock_stream(request)
+            metadata = gRPCServer.get_metadata(stream)
+
+            found = false
+            for (name, value) in metadata
+                if name == "authorization"
+                    @test value == "Bearer token123"
+                    found = true
+                end
+            end
+            @test found
+        end
+
+        @testset "Metadata case-insensitive lookup" begin
+            request = TestUtils.MockHTTP2Request(
+                metadata=Dict("X-Custom-Header" => "value")
+            )
+            stream = TestUtils.create_mock_stream(request)
+
+            # Should find with any case
+            @test gRPCServer.get_header(stream, "x-custom-header") == "value"
+            @test gRPCServer.get_header(stream, "X-CUSTOM-HEADER") == "value"
+        end
+
+    end  # T027
+
+    # =========================================================================
+    # T028: Binary Metadata Headers (-bin suffix)
+    # =========================================================================
+
+    @testset "T028: Binary metadata headers" begin
+
+        @testset "Binary header suffix convention" begin
+            # Binary headers MUST end with "-bin"
+            @test endswith("x-custom-bin", "-bin")
+            @test !endswith("x-custom", "-bin")
+        end
+
+        @testset "Binary metadata base64 decoding" begin
+            for (header_name, raw_value, is_binary, expected) in ConformanceData.BINARY_METADATA_TEST_CASES
+                if is_binary
+                    decoded = base64decode(raw_value)
+                    @test decoded == expected
+                end
+            end
+        end
+
+        @testset "Context handles binary response headers" begin
+            ctx = gRPCServer.ServerContext()
+            binary_data = UInt8[0x01, 0x02, 0x03, 0x04]
+            gRPCServer.set_header!(ctx, "x-trace-bin", binary_data)
+
+            headers = gRPCServer.get_response_headers(ctx)
+            for (name, value) in headers
+                if name == "x-trace-bin"
+                    # Should be base64 encoded
+                    @test value isa String
+                    @test base64decode(value) == binary_data
+                end
+            end
+        end
+
+        @testset "Context handles binary trailers" begin
+            ctx = gRPCServer.ServerContext()
+            binary_data = UInt8[0xDE, 0xAD, 0xBE, 0xEF]
+            gRPCServer.set_trailer!(ctx, "x-result-bin", binary_data)
+
+            trailers = gRPCServer.get_response_trailers(ctx, 0, "")
+            for (name, value) in trailers
+                if name == "x-result-bin"
+                    @test value isa String
+                    @test base64decode(value) == binary_data
+                end
+            end
+        end
+
+    end  # T028
+
+    # =========================================================================
+    # T029: Duplicate Headers
+    # =========================================================================
+
+    @testset "T029: Duplicate headers" begin
+
+        @testset "Multiple headers with same name preserved" begin
+            headers = [
+                (":method", "POST"),
+                (":path", "/test/Method"),
+                (":scheme", "http"),
+                (":authority", "localhost"),
+                ("content-type", "application/grpc"),
+                ("x-multi", "value1"),
+                ("x-multi", "value2"),
+                ("x-multi", "value3"),
+            ]
+
+            stream = gRPCServer.HTTP2Stream(UInt32(1))
+            stream.request_headers = headers
+            stream.headers_complete = true
+
+            values = gRPCServer.get_headers(stream, "x-multi")
+            @test length(values) == 3
+        end
+
+        @testset "Duplicate headers preserve order" begin
+            headers = [
+                (":method", "POST"),
+                (":path", "/test/Method"),
+                (":scheme", "http"),
+                (":authority", "localhost"),
+                ("content-type", "application/grpc"),
+                ("x-ordered", "first"),
+                ("x-ordered", "second"),
+                ("x-ordered", "third"),
+            ]
+
+            stream = gRPCServer.HTTP2Stream(UInt32(1))
+            stream.request_headers = headers
+            stream.headers_complete = true
+
+            values = gRPCServer.get_headers(stream, "x-ordered")
+            @test values[1] == "first"
+            @test values[2] == "second"
+            @test values[3] == "third"
+        end
+
+        @testset "get_header returns first value" begin
+            headers = [
+                (":method", "POST"),
+                (":path", "/test/Method"),
+                (":scheme", "http"),
+                (":authority", "localhost"),
+                ("content-type", "application/grpc"),
+                ("x-first", "value1"),
+                ("x-first", "value2"),
+            ]
+
+            stream = gRPCServer.HTTP2Stream(UInt32(1))
+            stream.request_headers = headers
+            stream.headers_complete = true
+
+            # get_header returns first occurrence
+            @test gRPCServer.get_header(stream, "x-first") == "value1"
+        end
+
+    end  # T029
+
+    # =========================================================================
+    # T030: Reserved Headers Filtering
+    # =========================================================================
+
+    @testset "T030: Reserved headers filtering" begin
+
+        @testset "Pseudo-headers excluded from metadata" begin
+            request = TestUtils.MockHTTP2Request(
+                metadata=Dict("x-custom" => "value")
+            )
+            stream = TestUtils.create_mock_stream(request)
+            metadata = gRPCServer.get_metadata(stream)
+
+            for (name, _) in metadata
+                @test !startswith(name, ":")
+            end
+        end
+
+        @testset "Reserved gRPC headers excluded from metadata" begin
+            headers = [
+                (":method", "POST"),
+                (":path", "/test/Method"),
+                (":scheme", "http"),
+                (":authority", "localhost"),
+                ("content-type", "application/grpc"),
+                ("te", "trailers"),
+                ("grpc-encoding", "gzip"),
+                ("grpc-accept-encoding", "gzip,deflate"),
+                ("grpc-timeout", "10S"),
+                ("x-custom", "custom-value"),
+            ]
+
+            stream = gRPCServer.HTTP2Stream(UInt32(1))
+            stream.request_headers = headers
+            stream.headers_complete = true
+
+            metadata = gRPCServer.get_metadata(stream)
+            metadata_names = [name for (name, _) in metadata]
+
+            # Reserved headers should not be in metadata
+            @test "content-type" ∉ metadata_names
+            @test "te" ∉ metadata_names
+            @test "grpc-encoding" ∉ metadata_names
+            @test "grpc-accept-encoding" ∉ metadata_names
+            @test "grpc-timeout" ∉ metadata_names
+
+            # Custom headers should be included
+            @test "x-custom" ∈ metadata_names
+        end
+
+        @testset "Context metadata access" begin
+            headers = [
+                (":method", "POST"),
+                (":path", "/test/Method"),
+                (":scheme", "http"),
+                (":authority", "localhost"),
+                ("content-type", "application/grpc"),
+                ("x-request-id", "abc123"),
+                ("authorization", "Bearer token"),
+            ]
+
+            stream = gRPCServer.HTTP2Stream(UInt32(1))
+            stream.request_headers = headers
+
+            peer = gRPCServer.PeerInfo(Sockets.IPv4("127.0.0.1"), 12345)
+            ctx = gRPCServer.create_context_from_headers(headers, peer)
+
+            # Should be able to get custom metadata
+            @test gRPCServer.get_metadata(ctx, "x-request-id") == "abc123"
+            @test gRPCServer.get_metadata(ctx, "authorization") == "Bearer token"
+
+            # Non-existent metadata returns nothing
+            @test gRPCServer.get_metadata(ctx, "x-nonexistent") === nothing
+        end
+
+    end  # T030
+
+end  # AC4: Custom Metadata

--- a/test/unit/test_error_mapping.jl
+++ b/test/unit/test_error_mapping.jl
@@ -1,0 +1,267 @@
+# AC5: Error Mapping Tests
+# Tests per gRPC HTTP/2 Protocol Specification
+# Reference: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
+
+using Test
+using gRPCServer
+
+# Include conformance test data
+include("../fixtures/conformance_data.jl")
+using .ConformanceData
+
+@testset "AC5: Error Mapping" begin
+
+    # =========================================================================
+    # T031: gRPC Status Codes
+    # =========================================================================
+
+    @testset "T031: gRPC status codes" begin
+
+        @testset "All 17 status codes defined" begin
+            @test Int(StatusCode.OK) == 0
+            @test Int(StatusCode.CANCELLED) == 1
+            @test Int(StatusCode.UNKNOWN) == 2
+            @test Int(StatusCode.INVALID_ARGUMENT) == 3
+            @test Int(StatusCode.DEADLINE_EXCEEDED) == 4
+            @test Int(StatusCode.NOT_FOUND) == 5
+            @test Int(StatusCode.ALREADY_EXISTS) == 6
+            @test Int(StatusCode.PERMISSION_DENIED) == 7
+            @test Int(StatusCode.RESOURCE_EXHAUSTED) == 8
+            @test Int(StatusCode.FAILED_PRECONDITION) == 9
+            @test Int(StatusCode.ABORTED) == 10
+            @test Int(StatusCode.OUT_OF_RANGE) == 11
+            @test Int(StatusCode.UNIMPLEMENTED) == 12
+            @test Int(StatusCode.INTERNAL) == 13
+            @test Int(StatusCode.UNAVAILABLE) == 14
+            @test Int(StatusCode.DATA_LOSS) == 15
+            @test Int(StatusCode.UNAUTHENTICATED) == 16
+        end
+
+        @testset "Status codes match conformance data" begin
+            for (code, name) in ConformanceData.GRPC_STATUS_CODES
+                # Verify the name matches the expected value
+                @test code >= 0 && code <= 16
+            end
+        end
+
+    end  # T031
+
+    # =========================================================================
+    # T032: HTTP/2 to gRPC Status Mapping
+    # =========================================================================
+
+    @testset "T032: HTTP/2 to gRPC status mapping" begin
+
+        @testset "CANCEL (0x08) → CANCELLED" begin
+            @test http2_to_grpc_status(0x08) == StatusCode.CANCELLED
+        end
+
+        @testset "REFUSED_STREAM (0x07) → UNAVAILABLE" begin
+            @test http2_to_grpc_status(0x07) == StatusCode.UNAVAILABLE
+        end
+
+        @testset "ENHANCE_YOUR_CALM (0x0b) → RESOURCE_EXHAUSTED" begin
+            @test http2_to_grpc_status(0x0b) == StatusCode.RESOURCE_EXHAUSTED
+        end
+
+        @testset "INADEQUATE_SECURITY (0x0c) → PERMISSION_DENIED" begin
+            @test http2_to_grpc_status(0x0c) == StatusCode.PERMISSION_DENIED
+        end
+
+        @testset "All other HTTP/2 errors → INTERNAL" begin
+            # NO_ERROR
+            @test http2_to_grpc_status(0x00) == StatusCode.INTERNAL
+            # PROTOCOL_ERROR
+            @test http2_to_grpc_status(0x01) == StatusCode.INTERNAL
+            # INTERNAL_ERROR
+            @test http2_to_grpc_status(0x02) == StatusCode.INTERNAL
+            # FLOW_CONTROL_ERROR
+            @test http2_to_grpc_status(0x03) == StatusCode.INTERNAL
+            # SETTINGS_TIMEOUT
+            @test http2_to_grpc_status(0x04) == StatusCode.INTERNAL
+            # STREAM_CLOSED
+            @test http2_to_grpc_status(0x05) == StatusCode.INTERNAL
+            # FRAME_SIZE_ERROR
+            @test http2_to_grpc_status(0x06) == StatusCode.INTERNAL
+            # COMPRESSION_ERROR
+            @test http2_to_grpc_status(0x09) == StatusCode.INTERNAL
+            # CONNECT_ERROR
+            @test http2_to_grpc_status(0x0a) == StatusCode.INTERNAL
+            # HTTP_1_1_REQUIRED
+            @test http2_to_grpc_status(0x0d) == StatusCode.INTERNAL
+        end
+
+        @testset "All error mapping test cases" begin
+            for (http2_code, name, expected_grpc) in ConformanceData.ERROR_MAPPING_TEST_CASES
+                result = Int(http2_to_grpc_status(UInt32(http2_code)))
+                @test result == expected_grpc
+            end
+        end
+
+    end  # T032
+
+    # =========================================================================
+    # T033: gRPC to HTTP Status Mapping
+    # =========================================================================
+
+    @testset "T033: gRPC to HTTP status mapping" begin
+
+        @testset "OK (0) → 200" begin
+            @test status_code_to_http(StatusCode.OK) == 200
+        end
+
+        @testset "INVALID_ARGUMENT (3) → 400" begin
+            @test status_code_to_http(StatusCode.INVALID_ARGUMENT) == 400
+        end
+
+        @testset "UNAUTHENTICATED (16) → 401" begin
+            @test status_code_to_http(StatusCode.UNAUTHENTICATED) == 401
+        end
+
+        @testset "PERMISSION_DENIED (7) → 403" begin
+            @test status_code_to_http(StatusCode.PERMISSION_DENIED) == 403
+        end
+
+        @testset "NOT_FOUND (5) → 404" begin
+            @test status_code_to_http(StatusCode.NOT_FOUND) == 404
+        end
+
+        @testset "RESOURCE_EXHAUSTED (8) → 429" begin
+            @test status_code_to_http(StatusCode.RESOURCE_EXHAUSTED) == 429
+        end
+
+        @testset "UNIMPLEMENTED (12) → 501" begin
+            @test status_code_to_http(StatusCode.UNIMPLEMENTED) == 501
+        end
+
+        @testset "UNAVAILABLE (14) → 503" begin
+            @test status_code_to_http(StatusCode.UNAVAILABLE) == 503
+        end
+
+        @testset "DEADLINE_EXCEEDED (4) → 504" begin
+            @test status_code_to_http(StatusCode.DEADLINE_EXCEEDED) == 504
+        end
+
+        @testset "Internal errors → 500" begin
+            @test status_code_to_http(StatusCode.INTERNAL) == 500
+            @test status_code_to_http(StatusCode.UNKNOWN) == 500
+            @test status_code_to_http(StatusCode.DATA_LOSS) == 500
+        end
+
+    end  # T033
+
+    # =========================================================================
+    # T034: Exception to Status Code Mapping
+    # =========================================================================
+
+    @testset "T034: Exception to status code mapping" begin
+
+        @testset "GRPCError preserves code" begin
+            err = GRPCError(StatusCode.NOT_FOUND, "Not found")
+            @test exception_to_status_code(err) == StatusCode.NOT_FOUND
+
+            err2 = GRPCError(StatusCode.PERMISSION_DENIED, "Access denied")
+            @test exception_to_status_code(err2) == StatusCode.PERMISSION_DENIED
+        end
+
+        @testset "ArgumentError → INVALID_ARGUMENT" begin
+            err = ArgumentError("invalid")
+            @test exception_to_status_code(err) == StatusCode.INVALID_ARGUMENT
+        end
+
+        @testset "BoundsError → OUT_OF_RANGE" begin
+            err = BoundsError([1,2,3], 10)
+            @test exception_to_status_code(err) == StatusCode.OUT_OF_RANGE
+        end
+
+        @testset "KeyError → NOT_FOUND" begin
+            err = KeyError("missing_key")
+            @test exception_to_status_code(err) == StatusCode.NOT_FOUND
+        end
+
+        @testset "InterruptException → CANCELLED" begin
+            err = InterruptException()
+            @test exception_to_status_code(err) == StatusCode.CANCELLED
+        end
+
+        @testset "Other exceptions → INTERNAL" begin
+            err = ErrorException("unknown")
+            @test exception_to_status_code(err) == StatusCode.INTERNAL
+        end
+
+    end  # T034
+
+    # =========================================================================
+    # T035: GRPCError Structure
+    # =========================================================================
+
+    @testset "T035: GRPCError structure" begin
+
+        @testset "GRPCError fields" begin
+            err = GRPCError(StatusCode.INVALID_ARGUMENT, "Bad input", Any["detail1", "detail2"])
+            @test err.code == StatusCode.INVALID_ARGUMENT
+            @test err.message == "Bad input"
+            @test length(err.details) == 2
+        end
+
+        @testset "GRPCError default details" begin
+            err = GRPCError(StatusCode.NOT_FOUND, "Resource not found")
+            @test isempty(err.details)
+        end
+
+        @testset "GRPCError is an Exception" begin
+            @test GRPCError <: Exception
+        end
+
+        @testset "GRPCError show method" begin
+            err = GRPCError(StatusCode.INTERNAL, "Something went wrong")
+            str = sprint(showerror, err)
+            @test occursin("GRPCError", str)
+            @test occursin("INTERNAL", str)
+            @test occursin("Something went wrong", str)
+        end
+
+    end  # T035
+
+    # =========================================================================
+    # T036: Error Response Format
+    # =========================================================================
+
+    @testset "T036: Error response format" begin
+
+        @testset "Error trailers format" begin
+            ctx = gRPCServer.ServerContext()
+            trailers = gRPCServer.get_response_trailers(ctx, 3, "Invalid argument provided")
+
+            # Must have grpc-status
+            status_found = false
+            message_found = false
+            for (name, value) in trailers
+                if name == "grpc-status"
+                    @test value == "3"
+                    status_found = true
+                elseif name == "grpc-message"
+                    @test length(value) > 0
+                    message_found = true
+                end
+            end
+            @test status_found
+            @test message_found
+        end
+
+        @testset "Empty message omitted" begin
+            ctx = gRPCServer.ServerContext()
+            trailers = gRPCServer.get_response_trailers(ctx, 0, "")
+
+            # grpc-status present
+            has_status = any(name == "grpc-status" for (name, _) in trailers)
+            @test has_status
+
+            # grpc-message not present for empty message
+            has_message = any(name == "grpc-message" for (name, _) in trailers)
+            @test !has_message
+        end
+
+    end  # T036
+
+end  # AC5: Error Mapping

--- a/test/unit/test_grpc_protocol.jl
+++ b/test/unit/test_grpc_protocol.jl
@@ -1,0 +1,387 @@
+# gRPC Protocol Conformance Tests
+# Reference: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
+
+using Test
+using gRPCServer
+using Base64
+
+# Include conformance test data
+include("../fixtures/conformance_data.jl")
+using .ConformanceData
+
+@testset "gRPC Protocol Conformance" begin
+
+    # =========================================================================
+    # AC1: Request Validation Tests
+    # =========================================================================
+
+    @testset "AC1: Request Validation" begin
+
+        @testset "Method validation - POST required" begin
+            # Spec: Request → Request-Headers *Length-Prefixed-Message EOS
+            # The :method pseudo-header MUST be POST
+
+            # Valid: POST method
+            request = TestUtils.MockHTTP2Request(method="POST")
+            headers = TestUtils.create_mock_headers(request)
+            valid, msg = TestUtils.validate_grpc_request_headers(headers)
+            @test valid
+            @test msg == ""
+
+            # Invalid: Non-POST methods
+            for invalid_method in ConformanceData.INVALID_METHODS
+                request = TestUtils.MockHTTP2Request(method=invalid_method)
+                headers = TestUtils.create_mock_headers(request)
+                valid, msg = TestUtils.validate_grpc_request_headers(headers)
+                @test !valid
+                @test occursin("POST", msg)
+            end
+        end
+
+        @testset "Content-type validation - application/grpc required" begin
+            # Spec: content-type → "application/grpc" ["+proto" / "+json" / {custom}]
+
+            # Valid content-types
+            for (ct, is_valid, _) in ConformanceData.CONTENT_TYPE_TEST_CASES
+                if is_valid
+                    request = TestUtils.MockHTTP2Request(content_type=ct)
+                    headers = TestUtils.create_mock_headers(request)
+                    valid, _ = TestUtils.validate_grpc_request_headers(headers)
+                    @test valid
+                end
+            end
+
+            # Invalid content-types
+            for (ct, is_valid, _) in ConformanceData.CONTENT_TYPE_TEST_CASES
+                if !is_valid && ct != ""
+                    request = TestUtils.MockHTTP2Request(content_type=ct)
+                    headers = TestUtils.create_mock_headers(request)
+                    valid, msg = TestUtils.validate_grpc_request_headers(headers)
+                    @test !valid
+                    @test occursin("content-type", lowercase(msg))
+                end
+            end
+
+            # Missing content-type
+            request = TestUtils.MockHTTP2Request(content_type=nothing)
+            headers = TestUtils.create_mock_headers(request)
+            valid, msg = TestUtils.validate_grpc_request_headers(headers)
+            @test !valid
+            @test occursin("content-type", lowercase(msg))
+        end
+
+        @testset "Path format validation - /{service}/{method}" begin
+            # Spec: :path → "/" Service-Name "/" {method name}
+
+            # Valid paths
+            for path in ConformanceData.VALID_PATHS
+                request = TestUtils.MockHTTP2Request(path=path)
+                headers = TestUtils.create_mock_headers(request)
+                valid, _ = TestUtils.validate_grpc_request_headers(headers)
+                @test valid
+            end
+
+            # Invalid paths
+            for path in ConformanceData.INVALID_PATHS
+                request = TestUtils.MockHTTP2Request(path=path)
+                headers = TestUtils.create_mock_headers(request)
+                valid, msg = TestUtils.validate_grpc_request_headers(headers)
+                @test !valid
+            end
+        end
+
+        @testset "TE header - trailers (warning if missing)" begin
+            # Spec: te → "trailers" # Used to detect incompatible proxies
+
+            # Valid: TE: trailers present
+            request = TestUtils.MockHTTP2Request(te="trailers")
+            stream = TestUtils.create_mock_stream(request)
+            te_header = gRPCServer.get_header(stream, "te")
+            @test te_header == "trailers"
+
+            # Missing TE header should be handled (warning, not rejection)
+            request_no_te = TestUtils.MockHTTP2Request(te=nothing)
+            stream_no_te = TestUtils.create_mock_stream(request_no_te)
+            te_header_missing = gRPCServer.get_header(stream_no_te, "te")
+            @test te_header_missing === nothing
+            # Server should still accept request (warning only per research.md)
+        end
+
+    end  # AC1
+
+    # =========================================================================
+    # AC2: Response Format Tests
+    # =========================================================================
+
+    @testset "AC2: Response Format" begin
+
+        @testset "HTTP status must be 200" begin
+            # Spec: Response → Response-Headers *Length-Prefixed-Message Trailers
+            # All gRPC responses MUST use HTTP status 200
+
+            valid, _ = TestUtils.validate_grpc_response(status=200, grpc_status=0)
+            @test valid
+
+            # Non-200 status is invalid for gRPC
+            valid, msg = TestUtils.validate_grpc_response(status=400, grpc_status=3)
+            @test !valid
+            @test occursin("200", msg)
+        end
+
+        @testset "Response content-type must be application/grpc" begin
+            # Response should mirror request content-type or use default
+
+            valid, _ = TestUtils.validate_grpc_response(
+                status=200,
+                content_type="application/grpc",
+                grpc_status=0
+            )
+            @test valid
+
+            valid, _ = TestUtils.validate_grpc_response(
+                status=200,
+                content_type="application/grpc+proto",
+                grpc_status=0
+            )
+            @test valid
+
+            # Invalid response content-type
+            valid, msg = TestUtils.validate_grpc_response(
+                status=200,
+                content_type="application/json",
+                grpc_status=0
+            )
+            @test !valid
+        end
+
+        @testset "Trailers must include grpc-status" begin
+            # Spec: Trailers → grpc-status [grpc-message] [grpc-status-details-bin] *Custom-Metadata
+
+            # Valid: grpc-status present
+            valid, _ = TestUtils.validate_grpc_response(status=200, grpc_status=0)
+            @test valid
+
+            # All valid status codes
+            for code in 0:16
+                valid, _ = TestUtils.validate_grpc_response(status=200, grpc_status=code)
+                @test valid
+            end
+
+            # Invalid status codes
+            valid, msg = TestUtils.validate_grpc_response(status=200, grpc_status=17)
+            @test !valid
+            @test occursin("grpc-status", msg)
+        end
+
+        @testset "Trailers-only response for errors" begin
+            # Spec: In the case of an error, the body may be absent entirely
+            # "Trailers-Only" response format is valid for immediate errors
+
+            # Test that headers + trailers combined is valid (trailers-only format)
+            # This is validated by checking grpc-status is in headers for trailers-only
+            collector = TestUtils.MockResponseCollector()
+            TestUtils.parse_response_headers!(collector, [
+                (":status", "200"),
+                ("content-type", "application/grpc"),
+                ("grpc-status", "3"),
+                ("grpc-message", "Invalid argument"),
+            ])
+            @test collector.http_status == 200
+            @test collector.grpc_status == 3
+            @test collector.grpc_message == "Invalid argument"
+        end
+
+    end  # AC2
+
+    # =========================================================================
+    # AC3: Message Encoding Tests
+    # =========================================================================
+
+    @testset "AC3: Message Encoding" begin
+
+        @testset "Compressed flag encoding" begin
+            # Spec: Compressed-Flag → 0 / 1 # 0 for uncompressed, 1 for compressed
+
+            # Test uncompressed message
+            msg = TestUtils.build_grpc_message(UInt8[0x01, 0x02, 0x03])
+            @test msg[1] == 0x00  # Not compressed
+
+            # Test compressed flag
+            msg_compressed = TestUtils.build_grpc_message(UInt8[0x01, 0x02, 0x03]; compressed=true)
+            @test msg_compressed[1] == 0x01  # Compressed
+        end
+
+        @testset "Message length big-endian encoding" begin
+            # Spec: Message-Length → {4 bytes} # big-endian
+
+            # Test with known length
+            data = UInt8[0x01, 0x02, 0x03, 0x04, 0x05]  # 5 bytes
+            msg = TestUtils.build_grpc_message(data)
+
+            # Length should be in bytes 2-5 (big-endian)
+            @test msg[2] == 0x00
+            @test msg[3] == 0x00
+            @test msg[4] == 0x00
+            @test msg[5] == 0x05
+
+            # Verify data follows
+            @test msg[6:10] == data
+        end
+
+        @testset "Parse gRPC message" begin
+            # Test round-trip
+            original_data = UInt8[0xAA, 0xBB, 0xCC, 0xDD]
+            encoded = TestUtils.build_grpc_message(original_data)
+            compressed, decoded = TestUtils.parse_grpc_message(encoded)
+
+            @test !compressed
+            @test decoded == original_data
+        end
+
+        @testset "Message frame test cases" begin
+            for (input, expected_compressed, expected_len, expected_msg, should_fail) in ConformanceData.MESSAGE_FRAME_TEST_CASES
+                if should_fail
+                    @test_throws Exception TestUtils.parse_grpc_message(input)
+                else
+                    compressed, message = TestUtils.parse_grpc_message(input)
+                    @test compressed == (expected_compressed != 0x00)
+                    @test length(message) == expected_len
+                    @test message == expected_msg
+                end
+            end
+        end
+
+    end  # AC3
+
+    # =========================================================================
+    # AC4: Custom Metadata Tests
+    # =========================================================================
+
+    @testset "AC4: Custom Metadata" begin
+
+        @testset "Binary metadata base64 decode" begin
+            # Spec: Binary headers end with "-bin" suffix and are base64 encoded
+
+            for (header_name, raw_value, is_binary, expected) in ConformanceData.BINARY_METADATA_TEST_CASES
+                if is_binary
+                    decoded = Base64.base64decode(raw_value)
+                    @test decoded == expected
+                end
+            end
+        end
+
+        @testset "ASCII metadata preservation" begin
+            # ASCII headers should be preserved as-is
+
+            request = TestUtils.MockHTTP2Request(
+                metadata=Dict(
+                    "x-custom-header" => "custom-value",
+                    "authorization" => "Bearer token123"
+                )
+            )
+            stream = TestUtils.create_mock_stream(request)
+            metadata = gRPCServer.get_metadata(stream)
+
+            # Find custom headers
+            has_custom = false
+            has_auth = false
+            for (name, value) in metadata
+                if name == "x-custom-header"
+                    @test value == "custom-value"
+                    has_custom = true
+                elseif name == "authorization"
+                    @test value == "Bearer token123"
+                    has_auth = true
+                end
+            end
+            @test has_custom
+            @test has_auth
+        end
+
+        @testset "Duplicate header order preservation" begin
+            # Multiple headers with same name should preserve order
+
+            headers = [
+                (":method", "POST"),
+                (":path", "/test/Method"),
+                (":scheme", "http"),
+                (":authority", "localhost"),
+                ("content-type", "application/grpc"),
+                ("x-multi", "value1"),
+                ("x-multi", "value2"),
+                ("x-multi", "value3"),
+            ]
+
+            stream = gRPCServer.HTTP2Stream(UInt32(1))
+            stream.request_headers = headers
+            stream.headers_complete = true
+
+            values = gRPCServer.get_headers(stream, "x-multi")
+            @test length(values) == 3
+            @test values[1] == "value1"
+            @test values[2] == "value2"
+            @test values[3] == "value3"
+        end
+
+    end  # AC4
+
+    # =========================================================================
+    # AC5: Error Mapping Tests (Placeholder - detailed tests in test_errors.jl)
+    # =========================================================================
+
+    @testset "AC5: Error Mapping (basic)" begin
+
+        @testset "gRPC status codes are defined" begin
+            # Verify all 17 status codes are defined
+            @test Int(StatusCode.OK) == 0
+            @test Int(StatusCode.CANCELLED) == 1
+            @test Int(StatusCode.UNKNOWN) == 2
+            @test Int(StatusCode.INVALID_ARGUMENT) == 3
+            @test Int(StatusCode.DEADLINE_EXCEEDED) == 4
+            @test Int(StatusCode.NOT_FOUND) == 5
+            @test Int(StatusCode.ALREADY_EXISTS) == 6
+            @test Int(StatusCode.PERMISSION_DENIED) == 7
+            @test Int(StatusCode.RESOURCE_EXHAUSTED) == 8
+            @test Int(StatusCode.FAILED_PRECONDITION) == 9
+            @test Int(StatusCode.ABORTED) == 10
+            @test Int(StatusCode.OUT_OF_RANGE) == 11
+            @test Int(StatusCode.UNIMPLEMENTED) == 12
+            @test Int(StatusCode.INTERNAL) == 13
+            @test Int(StatusCode.UNAVAILABLE) == 14
+            @test Int(StatusCode.DATA_LOSS) == 15
+            @test Int(StatusCode.UNAUTHENTICATED) == 16
+        end
+
+    end  # AC5
+
+    # =========================================================================
+    # AC6: Connection Management (Placeholder - detailed tests in test_http2_conformance.jl)
+    # =========================================================================
+
+    @testset "AC6: Connection Management (basic)" begin
+
+        @testset "Connection preface constant" begin
+            @test gRPCServer.CONNECTION_PREFACE == b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+        end
+
+    end  # AC6
+
+    # =========================================================================
+    # AC7: Timeout Handling (Placeholder - detailed tests in test_context.jl)
+    # =========================================================================
+
+    @testset "AC7: Timeout Handling (basic)" begin
+
+        @testset "Timeout parsing" begin
+            # Basic timeout parsing test
+            deadline = gRPCServer.parse_grpc_timeout("30S")
+            @test deadline !== nothing
+
+            # Invalid timeout
+            deadline_invalid = gRPCServer.parse_grpc_timeout("")
+            @test deadline_invalid === nothing
+        end
+
+    end  # AC7
+
+end  # gRPC Protocol Conformance

--- a/test/unit/test_http2_conformance.jl
+++ b/test/unit/test_http2_conformance.jl
@@ -1,0 +1,427 @@
+# HTTP/2 Protocol Conformance Tests
+# Reference: RFC 7540 - Hypertext Transfer Protocol Version 2 (HTTP/2)
+
+using Test
+using gRPCServer
+
+# Include conformance test data
+include("../fixtures/conformance_data.jl")
+using .ConformanceData
+
+@testset "HTTP/2 Protocol Conformance" begin
+
+    # =========================================================================
+    # Frame Types and Constants
+    # =========================================================================
+
+    @testset "Frame types per RFC 7540" begin
+        @test gRPCServer.FrameType.DATA == 0x0
+        @test gRPCServer.FrameType.HEADERS == 0x1
+        @test gRPCServer.FrameType.PRIORITY == 0x2
+        @test gRPCServer.FrameType.RST_STREAM == 0x3
+        @test gRPCServer.FrameType.SETTINGS == 0x4
+        @test gRPCServer.FrameType.PUSH_PROMISE == 0x5
+        @test gRPCServer.FrameType.PING == 0x6
+        @test gRPCServer.FrameType.GOAWAY == 0x7
+        @test gRPCServer.FrameType.WINDOW_UPDATE == 0x8
+        @test gRPCServer.FrameType.CONTINUATION == 0x9
+    end
+
+    @testset "Frame flags per RFC 7540" begin
+        @test gRPCServer.FrameFlags.END_STREAM == 0x1
+        @test gRPCServer.FrameFlags.END_HEADERS == 0x4
+        @test gRPCServer.FrameFlags.PADDED == 0x8
+        @test gRPCServer.FrameFlags.PRIORITY_FLAG == 0x20
+        @test gRPCServer.FrameFlags.ACK == 0x1
+    end
+
+    @testset "Error codes per RFC 7540 Section 7" begin
+        @test gRPCServer.ErrorCode.NO_ERROR == 0x0
+        @test gRPCServer.ErrorCode.PROTOCOL_ERROR == 0x1
+        @test gRPCServer.ErrorCode.INTERNAL_ERROR == 0x2
+        @test gRPCServer.ErrorCode.FLOW_CONTROL_ERROR == 0x3
+        @test gRPCServer.ErrorCode.SETTINGS_TIMEOUT == 0x4
+        @test gRPCServer.ErrorCode.STREAM_CLOSED == 0x5
+        @test gRPCServer.ErrorCode.FRAME_SIZE_ERROR == 0x6
+        @test gRPCServer.ErrorCode.REFUSED_STREAM == 0x7
+        @test gRPCServer.ErrorCode.CANCEL == 0x8
+        @test gRPCServer.ErrorCode.COMPRESSION_ERROR == 0x9
+        @test gRPCServer.ErrorCode.CONNECT_ERROR == 0xa
+        @test gRPCServer.ErrorCode.ENHANCE_YOUR_CALM == 0xb
+        @test gRPCServer.ErrorCode.INADEQUATE_SECURITY == 0xc
+        @test gRPCServer.ErrorCode.HTTP_1_1_REQUIRED == 0xd
+    end
+
+    @testset "HTTP/2 constants" begin
+        @test gRPCServer.FRAME_HEADER_SIZE == 9
+        @test gRPCServer.DEFAULT_INITIAL_WINDOW_SIZE == 65535
+        @test gRPCServer.DEFAULT_MAX_FRAME_SIZE == 16384
+        @test gRPCServer.MIN_MAX_FRAME_SIZE == 16384
+        @test gRPCServer.MAX_MAX_FRAME_SIZE == 16777215  # 2^24 - 1
+        @test gRPCServer.DEFAULT_HEADER_TABLE_SIZE == 4096
+    end
+
+    @testset "Connection preface" begin
+        @test gRPCServer.CONNECTION_PREFACE == b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+        @test length(gRPCServer.CONNECTION_PREFACE) == 24
+    end
+
+    # =========================================================================
+    # Frame Header Encoding/Decoding
+    # =========================================================================
+
+    @testset "Frame header encoding" begin
+        header = gRPCServer.FrameHeader(100, gRPCServer.FrameType.DATA, 0x01, 5)
+        bytes = gRPCServer.encode_frame_header(header)
+
+        @test length(bytes) == 9
+
+        # Length (24 bits, big-endian): 100 = 0x000064
+        @test bytes[1] == 0x00
+        @test bytes[2] == 0x00
+        @test bytes[3] == 0x64
+
+        # Type
+        @test bytes[4] == gRPCServer.FrameType.DATA
+
+        # Flags
+        @test bytes[5] == 0x01
+
+        # Stream ID (31 bits, big-endian): 5 = 0x00000005
+        @test bytes[6] == 0x00
+        @test bytes[7] == 0x00
+        @test bytes[8] == 0x00
+        @test bytes[9] == 0x05
+    end
+
+    @testset "Frame header decoding" begin
+        # Build a frame header manually
+        bytes = UInt8[
+            0x00, 0x00, 0x64,  # Length: 100
+            0x00,              # Type: DATA
+            0x01,              # Flags: END_STREAM
+            0x00, 0x00, 0x00, 0x05  # Stream ID: 5
+        ]
+
+        header = gRPCServer.decode_frame_header(bytes)
+
+        @test header.length == 100
+        @test header.frame_type == gRPCServer.FrameType.DATA
+        @test header.flags == 0x01
+        @test header.stream_id == 5
+    end
+
+    @testset "Frame header round-trip" begin
+        original = gRPCServer.FrameHeader(256, gRPCServer.FrameType.HEADERS, 0x05, 1)
+        encoded = gRPCServer.encode_frame_header(original)
+        decoded = gRPCServer.decode_frame_header(encoded)
+
+        @test decoded.length == original.length
+        @test decoded.frame_type == original.frame_type
+        @test decoded.flags == original.flags
+        @test decoded.stream_id == original.stream_id
+    end
+
+    # =========================================================================
+    # PING Frame Tests (AC6)
+    # =========================================================================
+
+    @testset "AC6: PING frame handling" begin
+
+        @testset "PING receives ACK with same payload" begin
+            # Create PING frame
+            opaque_data = UInt8[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]
+            ping = gRPCServer.ping_frame(opaque_data)
+
+            @test ping.header.frame_type == gRPCServer.FrameType.PING
+            @test ping.header.stream_id == 0  # PING must be on stream 0
+            @test ping.header.length == 8
+            @test !gRPCServer.has_flag(ping.header, gRPCServer.FrameFlags.ACK)
+            @test ping.payload == opaque_data
+
+            # Create PING ACK with same data
+            ping_ack = gRPCServer.ping_frame(opaque_data; ack=true)
+            @test gRPCServer.has_flag(ping_ack.header, gRPCServer.FrameFlags.ACK)
+            @test ping_ack.payload == opaque_data
+        end
+
+        @testset "PING payload must be exactly 8 bytes" begin
+            # Valid: 8 bytes
+            @test_nowarn gRPCServer.ping_frame(zeros(UInt8, 8))
+
+            # Invalid: not 8 bytes
+            @test_throws ArgumentError gRPCServer.ping_frame(zeros(UInt8, 7))
+            @test_throws ArgumentError gRPCServer.ping_frame(zeros(UInt8, 9))
+        end
+
+        @testset "PING on connection (stream 0)" begin
+            conn = gRPCServer.HTTP2Connection()
+            conn.state = gRPCServer.ConnectionState.OPEN
+
+            opaque_data = UInt8[0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE]
+            ping_frame = gRPCServer.ping_frame(opaque_data)
+
+            response_frames = gRPCServer.process_ping_frame!(conn, ping_frame)
+
+            @test length(response_frames) == 1
+            ack_frame = response_frames[1]
+            @test ack_frame.header.frame_type == gRPCServer.FrameType.PING
+            @test gRPCServer.has_flag(ack_frame.header, gRPCServer.FrameFlags.ACK)
+            @test ack_frame.payload == opaque_data
+        end
+
+    end
+
+    # =========================================================================
+    # GOAWAY Frame Tests (AC6)
+    # =========================================================================
+
+    @testset "AC6: GOAWAY frame handling" begin
+
+        @testset "GOAWAY sent on graceful shutdown" begin
+            conn = gRPCServer.HTTP2Connection()
+            conn.state = gRPCServer.ConnectionState.OPEN
+            conn.last_client_stream_id = UInt32(5)
+
+            goaway = gRPCServer.send_goaway(conn, gRPCServer.ErrorCode.NO_ERROR)
+
+            @test goaway.header.frame_type == gRPCServer.FrameType.GOAWAY
+            @test goaway.header.stream_id == 0  # GOAWAY is on connection level
+            @test conn.goaway_sent
+            @test conn.state == gRPCServer.ConnectionState.CLOSING
+
+            # Parse GOAWAY frame
+            last_stream_id, error_code, debug_data = gRPCServer.parse_goaway_frame(goaway)
+            @test last_stream_id == 5
+            @test error_code == gRPCServer.ErrorCode.NO_ERROR
+        end
+
+        @testset "GOAWAY with error closes connection" begin
+            conn = gRPCServer.HTTP2Connection()
+            conn.state = gRPCServer.ConnectionState.OPEN
+
+            goaway = gRPCServer.send_goaway(conn, gRPCServer.ErrorCode.PROTOCOL_ERROR, Vector{UInt8}("protocol error"))
+
+            @test conn.state == gRPCServer.ConnectionState.CLOSED
+
+            last_stream_id, error_code, debug_data = gRPCServer.parse_goaway_frame(goaway)
+            @test error_code == gRPCServer.ErrorCode.PROTOCOL_ERROR
+            @test String(debug_data) == "protocol error"
+        end
+
+        @testset "GOAWAY frame encoding" begin
+            goaway = gRPCServer.goaway_frame(10, gRPCServer.ErrorCode.NO_ERROR, UInt8[])
+
+            @test goaway.header.frame_type == gRPCServer.FrameType.GOAWAY
+            @test goaway.header.length == 8  # 4 bytes last-stream-id + 4 bytes error code
+
+            # Verify encoding
+            payload = goaway.payload
+            # Last-Stream-ID: 10 in big-endian
+            @test payload[1] == 0x00
+            @test payload[2] == 0x00
+            @test payload[3] == 0x00
+            @test payload[4] == 0x0A
+            # Error code: NO_ERROR = 0
+            @test payload[5] == 0x00
+            @test payload[6] == 0x00
+            @test payload[7] == 0x00
+            @test payload[8] == 0x00
+        end
+
+    end
+
+    # =========================================================================
+    # SETTINGS Frame Tests
+    # =========================================================================
+
+    @testset "SETTINGS frame handling" begin
+
+        @testset "SETTINGS parameters" begin
+            @test gRPCServer.SettingsParameter.HEADER_TABLE_SIZE == 0x1
+            @test gRPCServer.SettingsParameter.ENABLE_PUSH == 0x2
+            @test gRPCServer.SettingsParameter.MAX_CONCURRENT_STREAMS == 0x3
+            @test gRPCServer.SettingsParameter.INITIAL_WINDOW_SIZE == 0x4
+            @test gRPCServer.SettingsParameter.MAX_FRAME_SIZE == 0x5
+            @test gRPCServer.SettingsParameter.MAX_HEADER_LIST_SIZE == 0x6
+        end
+
+        @testset "SETTINGS frame encoding/decoding" begin
+            settings = [
+                (UInt16(gRPCServer.SettingsParameter.MAX_CONCURRENT_STREAMS), UInt32(100)),
+                (UInt16(gRPCServer.SettingsParameter.INITIAL_WINDOW_SIZE), UInt32(65535)),
+            ]
+
+            frame = gRPCServer.settings_frame(settings)
+            @test frame.header.frame_type == gRPCServer.FrameType.SETTINGS
+            @test frame.header.stream_id == 0
+            @test frame.header.length == 12  # 2 settings * 6 bytes each
+
+            # Parse back
+            parsed = gRPCServer.parse_settings_frame(frame)
+            @test length(parsed) == 2
+            @test parsed[1] == (UInt16(gRPCServer.SettingsParameter.MAX_CONCURRENT_STREAMS), UInt32(100))
+            @test parsed[2] == (UInt16(gRPCServer.SettingsParameter.INITIAL_WINDOW_SIZE), UInt32(65535))
+        end
+
+        @testset "SETTINGS ACK" begin
+            ack_frame = gRPCServer.settings_frame(; ack=true)
+
+            @test gRPCServer.has_flag(ack_frame.header, gRPCServer.FrameFlags.ACK)
+            @test ack_frame.header.length == 0  # ACK must have empty payload
+        end
+
+    end
+
+    # =========================================================================
+    # WINDOW_UPDATE Frame Tests (AC6: Flow Control)
+    # =========================================================================
+
+    @testset "AC6: Flow control - WINDOW_UPDATE" begin
+
+        @testset "WINDOW_UPDATE frame encoding" begin
+            frame = gRPCServer.window_update_frame(0, 65535)
+
+            @test frame.header.frame_type == gRPCServer.FrameType.WINDOW_UPDATE
+            @test frame.header.length == 4
+            @test frame.header.stream_id == 0
+
+            # Parse increment
+            increment = gRPCServer.parse_window_update_frame(frame)
+            @test increment == 65535
+        end
+
+        @testset "WINDOW_UPDATE on stream" begin
+            frame = gRPCServer.window_update_frame(5, 32768)
+
+            @test frame.header.stream_id == 5
+
+            increment = gRPCServer.parse_window_update_frame(frame)
+            @test increment == 32768
+        end
+
+        @testset "WINDOW_UPDATE increment validation" begin
+            # Increment must be 1 to 2^31-1
+            @test_nowarn gRPCServer.window_update_frame(0, 1)
+            @test_nowarn gRPCServer.window_update_frame(0, 2147483647)  # 2^31 - 1
+
+            # Invalid: 0
+            @test_throws ArgumentError gRPCServer.window_update_frame(0, 0)
+        end
+
+    end
+
+    # =========================================================================
+    # RST_STREAM Frame Tests
+    # =========================================================================
+
+    @testset "RST_STREAM frame handling" begin
+
+        @testset "RST_STREAM frame encoding" begin
+            frame = gRPCServer.rst_stream_frame(5, gRPCServer.ErrorCode.CANCEL)
+
+            @test frame.header.frame_type == gRPCServer.FrameType.RST_STREAM
+            @test frame.header.stream_id == 5
+            @test frame.header.length == 4
+
+            # Error code: CANCEL = 0x08
+            @test frame.payload[1] == 0x00
+            @test frame.payload[2] == 0x00
+            @test frame.payload[3] == 0x00
+            @test frame.payload[4] == 0x08
+        end
+
+    end
+
+    # =========================================================================
+    # Stream State Machine Tests
+    # =========================================================================
+
+    @testset "Stream state machine" begin
+
+        @testset "Stream states per RFC 7540 Section 5.1" begin
+            @test gRPCServer.StreamState.IDLE isa gRPCServer.StreamState.T
+            @test gRPCServer.StreamState.OPEN isa gRPCServer.StreamState.T
+            @test gRPCServer.StreamState.HALF_CLOSED_LOCAL isa gRPCServer.StreamState.T
+            @test gRPCServer.StreamState.HALF_CLOSED_REMOTE isa gRPCServer.StreamState.T
+            @test gRPCServer.StreamState.CLOSED isa gRPCServer.StreamState.T
+        end
+
+        @testset "Stream transitions: IDLE -> OPEN on HEADERS" begin
+            stream = gRPCServer.HTTP2Stream(UInt32(1))
+            @test stream.state == gRPCServer.StreamState.IDLE
+
+            gRPCServer.receive_headers!(stream, false)  # Not END_STREAM
+            @test stream.state == gRPCServer.StreamState.OPEN
+        end
+
+        @testset "Stream transitions: IDLE -> HALF_CLOSED_REMOTE on HEADERS with END_STREAM" begin
+            stream = gRPCServer.HTTP2Stream(UInt32(1))
+            @test stream.state == gRPCServer.StreamState.IDLE
+
+            gRPCServer.receive_headers!(stream, true)  # END_STREAM
+            @test stream.state == gRPCServer.StreamState.HALF_CLOSED_REMOTE
+            @test stream.end_stream_received
+        end
+
+        @testset "Stream transitions: OPEN -> HALF_CLOSED_LOCAL on send END_STREAM" begin
+            stream = gRPCServer.HTTP2Stream(UInt32(1))
+            stream.state = gRPCServer.StreamState.OPEN
+
+            gRPCServer.send_headers!(stream, true)  # END_STREAM
+            @test stream.state == gRPCServer.StreamState.HALF_CLOSED_LOCAL
+            @test stream.end_stream_sent
+        end
+
+        @testset "Client vs server initiated streams" begin
+            @test gRPCServer.is_client_initiated(1)
+            @test gRPCServer.is_client_initiated(3)
+            @test gRPCServer.is_client_initiated(5)
+            @test !gRPCServer.is_client_initiated(2)
+            @test !gRPCServer.is_client_initiated(4)
+
+            @test gRPCServer.is_server_initiated(2)
+            @test gRPCServer.is_server_initiated(4)
+            @test !gRPCServer.is_server_initiated(1)
+            @test !gRPCServer.is_server_initiated(0)  # Stream 0 is connection-level
+        end
+
+    end
+
+    # =========================================================================
+    # Connection Preface Processing
+    # =========================================================================
+
+    @testset "Connection preface processing" begin
+
+        @testset "Valid connection preface" begin
+            conn = gRPCServer.HTTP2Connection()
+            @test conn.state == gRPCServer.ConnectionState.PREFACE
+
+            preface = Vector{UInt8}(gRPCServer.CONNECTION_PREFACE)
+            success, response_frames = gRPCServer.process_preface(conn, preface)
+
+            @test success
+            @test conn.state == gRPCServer.ConnectionState.OPEN
+            @test length(response_frames) >= 1
+            # First response frame should be SETTINGS
+            @test response_frames[1].header.frame_type == gRPCServer.FrameType.SETTINGS
+        end
+
+        @testset "Invalid connection preface" begin
+            conn = gRPCServer.HTTP2Connection()
+
+            # Preface that matches in length but has wrong content throws error
+            invalid_preface = Vector{UInt8}("PRI * HTTP/1.1\r\n\r\nSM\r\n\r\n")
+            @test_throws gRPCServer.ConnectionError gRPCServer.process_preface(conn, invalid_preface)
+
+            # Too short preface returns false (not enough data yet)
+            conn2 = gRPCServer.HTTP2Connection()
+            short_preface = Vector{UInt8}("PRI")
+            success, _ = gRPCServer.process_preface(conn2, short_preface)
+            @test !success
+        end
+
+    end
+
+end  # HTTP/2 Protocol Conformance

--- a/test/unit/test_message_encoding.jl
+++ b/test/unit/test_message_encoding.jl
@@ -1,0 +1,254 @@
+# AC3: Message Encoding Tests
+# Tests per gRPC HTTP/2 Protocol Specification
+# Reference: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
+
+using Test
+using gRPCServer
+
+# Include conformance test data
+include("../fixtures/conformance_data.jl")
+using .ConformanceData
+
+@testset "AC3: Message Encoding" begin
+
+    # =========================================================================
+    # T021: Length-Prefixed Message Format
+    # =========================================================================
+
+    @testset "T021: Length-prefixed message format" begin
+
+        @testset "Build message: 1 byte flag + 4 bytes length + data" begin
+            data = UInt8[0x01, 0x02, 0x03, 0x04, 0x05]
+            msg = TestUtils.build_grpc_message(data)
+
+            # Total: 1 + 4 + 5 = 10 bytes
+            @test length(msg) == 10
+
+            # Compressed flag (byte 1)
+            @test msg[1] == 0x00  # Not compressed
+
+            # Length in big-endian (bytes 2-5)
+            @test msg[2] == 0x00
+            @test msg[3] == 0x00
+            @test msg[4] == 0x00
+            @test msg[5] == 0x05
+
+            # Data (bytes 6-10)
+            @test msg[6:10] == data
+        end
+
+        @testset "Build empty message" begin
+            data = UInt8[]
+            msg = TestUtils.build_grpc_message(data)
+
+            @test length(msg) == 5  # Just header
+            @test msg[1] == 0x00
+            @test msg[2] == 0x00
+            @test msg[3] == 0x00
+            @test msg[4] == 0x00
+            @test msg[5] == 0x00
+        end
+
+        @testset "Build large message (256 bytes)" begin
+            data = zeros(UInt8, 256)
+            msg = TestUtils.build_grpc_message(data)
+
+            @test length(msg) == 5 + 256
+
+            # Length = 256 = 0x00000100
+            @test msg[2] == 0x00
+            @test msg[3] == 0x00
+            @test msg[4] == 0x01
+            @test msg[5] == 0x00
+        end
+
+    end  # T021
+
+    # =========================================================================
+    # T022: Compressed Flag
+    # =========================================================================
+
+    @testset "T022: Compressed flag" begin
+
+        @testset "Uncompressed message: flag = 0" begin
+            data = UInt8[0xAA, 0xBB, 0xCC]
+            msg = TestUtils.build_grpc_message(data; compressed=false)
+            @test msg[1] == 0x00
+        end
+
+        @testset "Compressed message: flag = 1" begin
+            data = UInt8[0xAA, 0xBB, 0xCC]
+            msg = TestUtils.build_grpc_message(data; compressed=true)
+            @test msg[1] == 0x01
+        end
+
+        @testset "Parse compressed flag" begin
+            # Uncompressed
+            msg_uncomp = UInt8[0x00, 0x00, 0x00, 0x00, 0x03, 0x01, 0x02, 0x03]
+            compressed, _ = TestUtils.parse_grpc_message(msg_uncomp)
+            @test !compressed
+
+            # Compressed
+            msg_comp = UInt8[0x01, 0x00, 0x00, 0x00, 0x03, 0x01, 0x02, 0x03]
+            compressed, _ = TestUtils.parse_grpc_message(msg_comp)
+            @test compressed
+        end
+
+    end  # T022
+
+    # =========================================================================
+    # T023: Message Length Encoding (Big-Endian)
+    # =========================================================================
+
+    @testset "T023: Message length big-endian encoding" begin
+
+        @testset "Small message length" begin
+            data = UInt8[0x01]  # 1 byte
+            msg = TestUtils.build_grpc_message(data)
+            # Length = 1 = 0x00000001
+            @test msg[2:5] == UInt8[0x00, 0x00, 0x00, 0x01]
+        end
+
+        @testset "Medium message length (1024 bytes)" begin
+            data = zeros(UInt8, 1024)
+            msg = TestUtils.build_grpc_message(data)
+            # Length = 1024 = 0x00000400
+            @test msg[2:5] == UInt8[0x00, 0x00, 0x04, 0x00]
+        end
+
+        @testset "Large message length (65536 bytes)" begin
+            data = zeros(UInt8, 65536)
+            msg = TestUtils.build_grpc_message(data)
+            # Length = 65536 = 0x00010000
+            @test msg[2:5] == UInt8[0x00, 0x01, 0x00, 0x00]
+        end
+
+        @testset "Parse length correctly" begin
+            # Message with length = 256
+            msg = vcat(UInt8[0x00, 0x00, 0x00, 0x01, 0x00], zeros(UInt8, 256))
+            _, data = TestUtils.parse_grpc_message(msg)
+            @test length(data) == 256
+        end
+
+    end  # T023
+
+    # =========================================================================
+    # T024: Message Round-Trip
+    # =========================================================================
+
+    @testset "T024: Message encode/decode round-trip" begin
+
+        @testset "Round-trip small message" begin
+            original = UInt8[0x01, 0x02, 0x03, 0x04, 0x05]
+            encoded = TestUtils.build_grpc_message(original)
+            _, decoded = TestUtils.parse_grpc_message(encoded)
+            @test decoded == original
+        end
+
+        @testset "Round-trip empty message" begin
+            original = UInt8[]
+            encoded = TestUtils.build_grpc_message(original)
+            _, decoded = TestUtils.parse_grpc_message(encoded)
+            @test decoded == original
+        end
+
+        @testset "Round-trip compressed flag" begin
+            original = UInt8[0xAA, 0xBB]
+            encoded = TestUtils.build_grpc_message(original; compressed=true)
+            compressed, decoded = TestUtils.parse_grpc_message(encoded)
+            @test compressed
+            @test decoded == original
+        end
+
+        @testset "Round-trip binary data" begin
+            original = Vector{UInt8}(0:255)
+            encoded = TestUtils.build_grpc_message(original)
+            _, decoded = TestUtils.parse_grpc_message(encoded)
+            @test decoded == original
+        end
+
+    end  # T024
+
+    # =========================================================================
+    # T025: Invalid Message Handling
+    # =========================================================================
+
+    @testset "T025: Invalid message handling" begin
+
+        @testset "Message too short (< 5 bytes)" begin
+            @test_throws Exception TestUtils.parse_grpc_message(UInt8[0x00])
+            @test_throws Exception TestUtils.parse_grpc_message(UInt8[0x00, 0x00, 0x00])
+        end
+
+        @testset "Truncated message" begin
+            # Header says 5 bytes but only 2 bytes of data
+            msg = UInt8[0x00, 0x00, 0x00, 0x00, 0x05, 0x01, 0x02]
+            @test_throws Exception TestUtils.parse_grpc_message(msg)
+        end
+
+        @testset "Conformance test cases for invalid messages" begin
+            for (input, _, _, _, should_fail) in ConformanceData.MESSAGE_FRAME_TEST_CASES
+                if should_fail
+                    @test_throws Exception TestUtils.parse_grpc_message(input)
+                end
+            end
+        end
+
+    end  # T025
+
+    # =========================================================================
+    # T026: Compression Codec Integration
+    # =========================================================================
+
+    @testset "T026: Compression codec integration" begin
+
+        @testset "GZIP compress/decompress" begin
+            original = Vector{UInt8}("Hello, gRPC compression test! " ^ 10)
+            compressed = gRPCServer.compress(original, CompressionCodec.GZIP)
+            decompressed = gRPCServer.decompress(compressed, CompressionCodec.GZIP)
+            @test decompressed == original
+            @test length(compressed) < length(original)  # Should compress
+        end
+
+        @testset "DEFLATE compress/decompress" begin
+            original = Vector{UInt8}("Test data for deflate compression")
+            compressed = gRPCServer.compress(original, CompressionCodec.DEFLATE)
+            decompressed = gRPCServer.decompress(compressed, CompressionCodec.DEFLATE)
+            @test decompressed == original
+        end
+
+        @testset "IDENTITY codec is no-op" begin
+            original = UInt8[0x01, 0x02, 0x03]
+            @test gRPCServer.compress(original, CompressionCodec.IDENTITY) == original
+            @test gRPCServer.decompress(original, CompressionCodec.IDENTITY) == original
+        end
+
+        @testset "Parse grpc-encoding header" begin
+            @test gRPCServer.parse_codec("gzip") == CompressionCodec.GZIP
+            @test gRPCServer.parse_codec("deflate") == CompressionCodec.DEFLATE
+            @test gRPCServer.parse_codec("identity") == CompressionCodec.IDENTITY
+            @test gRPCServer.parse_codec("unknown") === nothing
+        end
+
+        @testset "Parse grpc-accept-encoding header" begin
+            codecs = gRPCServer.parse_accept_encoding("gzip, deflate, identity")
+            @test CompressionCodec.GZIP in codecs
+            @test CompressionCodec.DEFLATE in codecs
+            @test CompressionCodec.IDENTITY in codecs
+        end
+
+        @testset "Negotiate compression" begin
+            client_codecs = [CompressionCodec.GZIP, CompressionCodec.DEFLATE]
+            server_codecs = [CompressionCodec.DEFLATE, CompressionCodec.GZIP]
+            result = gRPCServer.negotiate_compression(client_codecs, server_codecs)
+            @test result == CompressionCodec.GZIP  # First match from client preference
+
+            # No common codec
+            empty_server = CompressionCodec.T[]
+            result = gRPCServer.negotiate_compression(client_codecs, empty_server)
+            @test result == CompressionCodec.IDENTITY  # Fallback
+        end
+
+    end  # T026
+
+end  # AC3: Message Encoding

--- a/test/unit/test_request_validation.jl
+++ b/test/unit/test_request_validation.jl
@@ -1,0 +1,379 @@
+# AC1: Request Validation Tests
+# Tests per gRPC HTTP/2 Protocol Specification
+# Reference: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
+
+using Test
+using gRPCServer
+
+# Include conformance test data
+include("../fixtures/conformance_data.jl")
+using .ConformanceData
+
+@testset "AC1: Request Validation" begin
+
+    # =========================================================================
+    # T008: Method Validation - POST required
+    # =========================================================================
+
+    @testset "T008: Method validation" begin
+
+        @testset "Valid: POST method accepted" begin
+            request = TestUtils.MockHTTP2Request(method="POST")
+            headers = TestUtils.create_mock_headers(request)
+            valid, msg = TestUtils.validate_grpc_request_headers(headers)
+            @test valid
+            @test msg == ""
+        end
+
+        @testset "Invalid: GET method rejected" begin
+            request = TestUtils.MockHTTP2Request(method="GET")
+            headers = TestUtils.create_mock_headers(request)
+            valid, msg = TestUtils.validate_grpc_request_headers(headers)
+            @test !valid
+            @test occursin("POST", msg)
+        end
+
+        @testset "Invalid: PUT method rejected" begin
+            request = TestUtils.MockHTTP2Request(method="PUT")
+            headers = TestUtils.create_mock_headers(request)
+            valid, msg = TestUtils.validate_grpc_request_headers(headers)
+            @test !valid
+        end
+
+        @testset "Invalid: DELETE method rejected" begin
+            request = TestUtils.MockHTTP2Request(method="DELETE")
+            headers = TestUtils.create_mock_headers(request)
+            valid, msg = TestUtils.validate_grpc_request_headers(headers)
+            @test !valid
+        end
+
+        @testset "Invalid: OPTIONS method rejected" begin
+            request = TestUtils.MockHTTP2Request(method="OPTIONS")
+            headers = TestUtils.create_mock_headers(request)
+            valid, msg = TestUtils.validate_grpc_request_headers(headers)
+            @test !valid
+        end
+
+        @testset "All invalid methods from test data" begin
+            for method in ConformanceData.INVALID_METHODS
+                request = TestUtils.MockHTTP2Request(method=method)
+                headers = TestUtils.create_mock_headers(request)
+                valid, _ = TestUtils.validate_grpc_request_headers(headers)
+                @test !valid
+            end
+        end
+
+    end  # T008
+
+    # =========================================================================
+    # T009: Content-Type Validation - application/grpc required
+    # =========================================================================
+
+    @testset "T009: Content-type validation" begin
+
+        @testset "Valid: application/grpc" begin
+            request = TestUtils.MockHTTP2Request(content_type="application/grpc")
+            headers = TestUtils.create_mock_headers(request)
+            valid, _ = TestUtils.validate_grpc_request_headers(headers)
+            @test valid
+        end
+
+        @testset "Valid: application/grpc+proto" begin
+            request = TestUtils.MockHTTP2Request(content_type="application/grpc+proto")
+            headers = TestUtils.create_mock_headers(request)
+            valid, _ = TestUtils.validate_grpc_request_headers(headers)
+            @test valid
+        end
+
+        @testset "Valid: application/grpc+json" begin
+            request = TestUtils.MockHTTP2Request(content_type="application/grpc+json")
+            headers = TestUtils.create_mock_headers(request)
+            valid, _ = TestUtils.validate_grpc_request_headers(headers)
+            @test valid
+        end
+
+        @testset "Valid: application/grpc with charset parameter" begin
+            request = TestUtils.MockHTTP2Request(content_type="application/grpc; charset=utf-8")
+            headers = TestUtils.create_mock_headers(request)
+            valid, _ = TestUtils.validate_grpc_request_headers(headers)
+            @test valid
+        end
+
+        @testset "Invalid: application/json" begin
+            request = TestUtils.MockHTTP2Request(content_type="application/json")
+            headers = TestUtils.create_mock_headers(request)
+            valid, msg = TestUtils.validate_grpc_request_headers(headers)
+            @test !valid
+            @test occursin("content-type", lowercase(msg))
+        end
+
+        @testset "Invalid: text/plain" begin
+            request = TestUtils.MockHTTP2Request(content_type="text/plain")
+            headers = TestUtils.create_mock_headers(request)
+            valid, _ = TestUtils.validate_grpc_request_headers(headers)
+            @test !valid
+        end
+
+        @testset "Invalid: missing content-type" begin
+            request = TestUtils.MockHTTP2Request(content_type=nothing)
+            headers = TestUtils.create_mock_headers(request)
+            valid, msg = TestUtils.validate_grpc_request_headers(headers)
+            @test !valid
+            @test occursin("content-type", lowercase(msg))
+        end
+
+        @testset "All content-type test cases" begin
+            for (ct, is_valid, _) in ConformanceData.CONTENT_TYPE_TEST_CASES
+                if ct == ""
+                    continue  # Skip empty string (handled by missing test)
+                end
+                request = TestUtils.MockHTTP2Request(content_type=ct)
+                headers = TestUtils.create_mock_headers(request)
+                valid, _ = TestUtils.validate_grpc_request_headers(headers)
+                @test valid == is_valid
+            end
+        end
+
+    end  # T009
+
+    # =========================================================================
+    # T010: Path Format Validation - /{service}/{method}
+    # =========================================================================
+
+    @testset "T010: Path format validation" begin
+
+        @testset "Valid: standard service path" begin
+            request = TestUtils.MockHTTP2Request(path="/helloworld.Greeter/SayHello")
+            headers = TestUtils.create_mock_headers(request)
+            valid, _ = TestUtils.validate_grpc_request_headers(headers)
+            @test valid
+        end
+
+        @testset "Valid: health check path" begin
+            request = TestUtils.MockHTTP2Request(path="/grpc.health.v1.Health/Check")
+            headers = TestUtils.create_mock_headers(request)
+            valid, _ = TestUtils.validate_grpc_request_headers(headers)
+            @test valid
+        end
+
+        @testset "Valid: minimal path" begin
+            request = TestUtils.MockHTTP2Request(path="/a/b")
+            headers = TestUtils.create_mock_headers(request)
+            valid, _ = TestUtils.validate_grpc_request_headers(headers)
+            @test valid
+        end
+
+        @testset "Invalid: empty path" begin
+            request = TestUtils.MockHTTP2Request(path="")
+            headers = TestUtils.create_mock_headers(request)
+            valid, _ = TestUtils.validate_grpc_request_headers(headers)
+            @test !valid
+        end
+
+        @testset "Invalid: root path only" begin
+            request = TestUtils.MockHTTP2Request(path="/")
+            headers = TestUtils.create_mock_headers(request)
+            valid, _ = TestUtils.validate_grpc_request_headers(headers)
+            @test !valid
+        end
+
+        @testset "Invalid: single segment" begin
+            request = TestUtils.MockHTTP2Request(path="/service")
+            headers = TestUtils.create_mock_headers(request)
+            valid, _ = TestUtils.validate_grpc_request_headers(headers)
+            @test !valid
+        end
+
+        @testset "Invalid: missing leading slash" begin
+            request = TestUtils.MockHTTP2Request(path="service/method")
+            headers = TestUtils.create_mock_headers(request)
+            valid, _ = TestUtils.validate_grpc_request_headers(headers)
+            @test !valid
+        end
+
+        @testset "All valid paths" begin
+            for path in ConformanceData.VALID_PATHS
+                request = TestUtils.MockHTTP2Request(path=path)
+                headers = TestUtils.create_mock_headers(request)
+                valid, _ = TestUtils.validate_grpc_request_headers(headers)
+                @test valid
+            end
+        end
+
+        @testset "All invalid paths" begin
+            for path in ConformanceData.INVALID_PATHS
+                request = TestUtils.MockHTTP2Request(path=path)
+                headers = TestUtils.create_mock_headers(request)
+                valid, _ = TestUtils.validate_grpc_request_headers(headers)
+                @test !valid
+            end
+        end
+
+    end  # T010
+
+    # =========================================================================
+    # T011: TE Header Validation (warning only, not rejection)
+    # =========================================================================
+
+    @testset "T011: TE header validation" begin
+
+        @testset "Valid: TE trailers present" begin
+            request = TestUtils.MockHTTP2Request(te="trailers")
+            stream = TestUtils.create_mock_stream(request)
+            te = gRPCServer.get_header(stream, "te")
+            @test te == "trailers"
+        end
+
+        @testset "Request accepted: TE header missing (warning only)" begin
+            request = TestUtils.MockHTTP2Request(te=nothing)
+            headers = TestUtils.create_mock_headers(request)
+            # Request should still be valid (warning only per spec interpretation)
+            valid, _ = TestUtils.validate_grpc_request_headers(headers)
+            @test valid
+        end
+
+        @testset "Request accepted: wrong TE value (warning only)" begin
+            request = TestUtils.MockHTTP2Request(te="chunked")
+            headers = TestUtils.create_mock_headers(request)
+            valid, _ = TestUtils.validate_grpc_request_headers(headers)
+            @test valid
+        end
+
+        @testset "Stream exposes TE header correctly" begin
+            for te_value in ["trailers", "chunked", "gzip"]
+                request = TestUtils.MockHTTP2Request(te=te_value)
+                stream = TestUtils.create_mock_stream(request)
+                te = gRPCServer.get_header(stream, "te")
+                @test te == te_value
+            end
+        end
+
+    end  # T011
+
+    # =========================================================================
+    # T012: Timeout Header Parsing
+    # =========================================================================
+
+    @testset "T012: Timeout header parsing" begin
+
+        @testset "Valid timeouts parse correctly" begin
+            # 30 seconds
+            deadline = gRPCServer.parse_grpc_timeout("30S")
+            @test deadline !== nothing
+
+            # 1 hour
+            deadline = gRPCServer.parse_grpc_timeout("1H")
+            @test deadline !== nothing
+
+            # 500 milliseconds
+            deadline = gRPCServer.parse_grpc_timeout("500m")
+            @test deadline !== nothing
+
+            # 5 minutes
+            deadline = gRPCServer.parse_grpc_timeout("5M")
+            @test deadline !== nothing
+        end
+
+        @testset "Invalid timeouts return nothing" begin
+            @test gRPCServer.parse_grpc_timeout("") === nothing
+            @test gRPCServer.parse_grpc_timeout("abc") === nothing
+            @test gRPCServer.parse_grpc_timeout("1X") === nothing
+            @test gRPCServer.parse_grpc_timeout("-1S") === nothing
+        end
+
+        @testset "All timeout test cases" begin
+            for (input, _, should_fail) in ConformanceData.TIMEOUT_TEST_CASES
+                result = gRPCServer.parse_grpc_timeout(input)
+                if should_fail
+                    @test result === nothing
+                else
+                    @test result !== nothing
+                end
+            end
+        end
+
+        @testset "Timeout creates deadline in future" begin
+            deadline = gRPCServer.parse_grpc_timeout("60S")
+            @test deadline !== nothing
+            @test deadline > Dates.now()
+        end
+
+    end  # T012
+
+    # =========================================================================
+    # T013: Authority/Host Validation
+    # =========================================================================
+
+    @testset "T013: Authority validation" begin
+
+        @testset "Authority header accessible" begin
+            request = TestUtils.MockHTTP2Request(authority="localhost:50051")
+            stream = TestUtils.create_mock_stream(request)
+            authority = gRPCServer.get_authority(stream)
+            @test authority == "localhost:50051"
+        end
+
+        @testset "Authority with different formats" begin
+            for auth in ["localhost:50051", "127.0.0.1:8080", "example.com:443", "api.service.local"]
+                request = TestUtils.MockHTTP2Request(authority=auth)
+                stream = TestUtils.create_mock_stream(request)
+                @test gRPCServer.get_authority(stream) == auth
+            end
+        end
+
+    end  # T013
+
+    # =========================================================================
+    # T014: Required Pseudo-Headers
+    # =========================================================================
+
+    @testset "T014: Required pseudo-headers" begin
+
+        @testset "All required pseudo-headers present" begin
+            headers = [
+                (":method", "POST"),
+                (":path", "/test.Service/Method"),
+                (":scheme", "http"),
+                (":authority", "localhost:50051"),
+                ("content-type", "application/grpc"),
+            ]
+            valid, _ = TestUtils.validate_grpc_request_headers(headers)
+            @test valid
+        end
+
+        @testset "Stream helpers for pseudo-headers" begin
+            request = TestUtils.MockHTTP2Request()
+            stream = TestUtils.create_mock_stream(request)
+
+            @test gRPCServer.get_method(stream) == "POST"
+            @test gRPCServer.get_path(stream) == "/pkg.Service/Method"
+            @test gRPCServer.get_authority(stream) == "localhost:50051"
+        end
+
+        @testset "Missing :path header fails validation" begin
+            headers = [
+                (":method", "POST"),
+                (":scheme", "http"),
+                (":authority", "localhost:50051"),
+                ("content-type", "application/grpc"),
+            ]
+            valid, msg = TestUtils.validate_grpc_request_headers(headers)
+            @test !valid
+            @test occursin("path", lowercase(msg))
+        end
+
+        @testset "Missing :method header fails validation" begin
+            headers = [
+                (":path", "/test.Service/Method"),
+                (":scheme", "http"),
+                (":authority", "localhost:50051"),
+                ("content-type", "application/grpc"),
+            ]
+            valid, msg = TestUtils.validate_grpc_request_headers(headers)
+            @test !valid
+            @test occursin("method", lowercase(msg))
+        end
+
+    end  # T014
+
+end  # AC1: Request Validation

--- a/test/unit/test_response_format.jl
+++ b/test/unit/test_response_format.jl
@@ -1,0 +1,255 @@
+# AC2: Response Format Tests
+# Tests per gRPC HTTP/2 Protocol Specification
+# Reference: https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md
+
+using Test
+using gRPCServer
+
+# Include conformance test data
+include("../fixtures/conformance_data.jl")
+using .ConformanceData
+
+@testset "AC2: Response Format" begin
+
+    # =========================================================================
+    # T015: HTTP Status 200 Required
+    # =========================================================================
+
+    @testset "T015: HTTP status must be 200" begin
+
+        @testset "Valid response with HTTP 200" begin
+            valid, _ = TestUtils.validate_grpc_response(status=200, grpc_status=0)
+            @test valid
+        end
+
+        @testset "Invalid response with HTTP 400" begin
+            valid, msg = TestUtils.validate_grpc_response(status=400, grpc_status=3)
+            @test !valid
+            @test occursin("200", msg)
+        end
+
+        @testset "Invalid response with HTTP 500" begin
+            valid, _ = TestUtils.validate_grpc_response(status=500, grpc_status=13)
+            @test !valid
+        end
+
+        @testset "All HTTP status codes except 200 invalid" begin
+            for status in [201, 204, 301, 302, 400, 401, 403, 404, 500, 502, 503]
+                valid, _ = TestUtils.validate_grpc_response(status=status, grpc_status=0)
+                @test !valid
+            end
+        end
+
+    end  # T015
+
+    # =========================================================================
+    # T016: Response Content-Type
+    # =========================================================================
+
+    @testset "T016: Response content-type" begin
+
+        @testset "Valid: application/grpc" begin
+            valid, _ = TestUtils.validate_grpc_response(
+                status=200,
+                content_type="application/grpc",
+                grpc_status=0
+            )
+            @test valid
+        end
+
+        @testset "Valid: application/grpc+proto" begin
+            valid, _ = TestUtils.validate_grpc_response(
+                status=200,
+                content_type="application/grpc+proto",
+                grpc_status=0
+            )
+            @test valid
+        end
+
+        @testset "Invalid: application/json" begin
+            valid, _ = TestUtils.validate_grpc_response(
+                status=200,
+                content_type="application/json",
+                grpc_status=0
+            )
+            @test !valid
+        end
+
+    end  # T016
+
+    # =========================================================================
+    # T017: Trailers with grpc-status
+    # =========================================================================
+
+    @testset "T017: grpc-status in trailers" begin
+
+        @testset "Valid: grpc-status 0 (OK)" begin
+            valid, _ = TestUtils.validate_grpc_response(status=200, grpc_status=0)
+            @test valid
+        end
+
+        @testset "All valid gRPC status codes" begin
+            for code in 0:16
+                valid, _ = TestUtils.validate_grpc_response(status=200, grpc_status=code)
+                @test valid
+            end
+        end
+
+        @testset "Invalid: grpc-status > 16" begin
+            valid, msg = TestUtils.validate_grpc_response(status=200, grpc_status=17)
+            @test !valid
+            @test occursin("grpc-status", msg)
+        end
+
+        @testset "Invalid: negative grpc-status" begin
+            valid, _ = TestUtils.validate_grpc_response(status=200, grpc_status=-1)
+            @test !valid
+        end
+
+    end  # T017
+
+    # =========================================================================
+    # T018: grpc-message Encoding
+    # =========================================================================
+
+    @testset "T018: grpc-message encoding" begin
+
+        @testset "URL encoding function exists" begin
+            @test isdefined(gRPCServer, :HTTP_urlencode)
+        end
+
+        @testset "URL encode ASCII text" begin
+            encoded = gRPCServer.HTTP_urlencode("Hello World")
+            @test encoded == "Hello%20World"
+        end
+
+        @testset "URL encode special characters" begin
+            encoded = gRPCServer.HTTP_urlencode("Test: value=123")
+            @test occursin("%3A", encoded)  # :
+            @test occursin("%3D", encoded)  # =
+        end
+
+        @testset "URL encode preserves safe characters" begin
+            # Per RFC 3986: unreserved = ALPHA / DIGIT / "-" / "." / "_" / "~"
+            safe = "abcABC123-._~"
+            encoded = gRPCServer.HTTP_urlencode(safe)
+            @test encoded == safe
+        end
+
+        @testset "Response trailers include grpc-message" begin
+            ctx = gRPCServer.ServerContext()
+            trailers = gRPCServer.get_response_trailers(ctx, 3, "Invalid argument")
+
+            has_status = false
+            has_message = false
+            for (name, value) in trailers
+                if name == "grpc-status"
+                    @test value == "3"
+                    has_status = true
+                elseif name == "grpc-message"
+                    has_message = true
+                end
+            end
+            @test has_status
+            @test has_message
+        end
+
+    end  # T018
+
+    # =========================================================================
+    # T019: Trailers-Only Response
+    # =========================================================================
+
+    @testset "T019: Trailers-only response" begin
+
+        @testset "Trailers-only response format" begin
+            # Trailers-only: headers contain both :status and grpc-status
+            collector = TestUtils.MockResponseCollector()
+            TestUtils.parse_response_headers!(collector, [
+                (":status", "200"),
+                ("content-type", "application/grpc"),
+                ("grpc-status", "12"),  # UNIMPLEMENTED
+                ("grpc-message", "Method%20not%20found"),
+            ])
+
+            @test collector.http_status == 200
+            @test collector.grpc_status == 12
+            @test collector.grpc_message == "Method%20not%20found"
+        end
+
+        @testset "Trailers-only valid for immediate errors" begin
+            # For immediate errors (UNIMPLEMENTED, INVALID_ARGUMENT, etc.)
+            # server can respond with trailers-only format
+            collector = TestUtils.MockResponseCollector()
+            TestUtils.parse_response_headers!(collector, [
+                (":status", "200"),
+                ("content-type", "application/grpc"),
+                ("grpc-status", "3"),
+                ("grpc-message", "Missing required field"),
+            ])
+
+            @test collector.grpc_status == 3  # INVALID_ARGUMENT
+        end
+
+    end  # T019
+
+    # =========================================================================
+    # T020: Response Headers Format
+    # =========================================================================
+
+    @testset "T020: Response headers format" begin
+
+        @testset "Context generates proper response headers" begin
+            ctx = gRPCServer.ServerContext()
+            gRPCServer.set_header!(ctx, "x-custom-header", "custom-value")
+
+            headers = gRPCServer.get_response_headers(ctx)
+            found = false
+            for (name, value) in headers
+                if name == "x-custom-header"
+                    @test value == "custom-value"
+                    found = true
+                end
+            end
+            @test found
+        end
+
+        @testset "Binary headers are base64 encoded" begin
+            ctx = gRPCServer.ServerContext()
+            binary_data = UInt8[0x01, 0x02, 0x03, 0x04]
+            gRPCServer.set_header!(ctx, "x-binary-bin", binary_data)
+
+            headers = gRPCServer.get_response_headers(ctx)
+            for (name, value) in headers
+                if name == "x-binary-bin"
+                    # Should be base64 encoded
+                    @test value isa String
+                    @test Base64.base64decode(value) == binary_data
+                end
+            end
+        end
+
+        @testset "Response trailers format" begin
+            ctx = gRPCServer.ServerContext()
+            gRPCServer.set_trailer!(ctx, "x-processing-time", "150ms")
+
+            trailers = gRPCServer.get_response_trailers(ctx, 0, "")
+
+            # Should contain grpc-status
+            has_status = any(name == "grpc-status" for (name, _) in trailers)
+            @test has_status
+
+            # Should contain custom trailer
+            has_custom = false
+            for (name, value) in trailers
+                if name == "x-processing-time"
+                    @test value == "150ms"
+                    has_custom = true
+                end
+            end
+            @test has_custom
+        end
+
+    end  # T020
+
+end  # AC2: Response Format

--- a/test/unit/test_timeout_handling.jl
+++ b/test/unit/test_timeout_handling.jl
@@ -1,0 +1,249 @@
+# AC7: Timeout Handling Tests
+# Tests per gRPC HTTP/2 Protocol Specification
+
+using Test
+using Dates
+using gRPCServer
+
+# Include conformance test data
+include("../fixtures/conformance_data.jl")
+using .ConformanceData
+
+@testset "AC7: Timeout Handling" begin
+
+    # =========================================================================
+    # T042: grpc-timeout Header Parsing
+    # =========================================================================
+
+    @testset "T042: grpc-timeout header parsing" begin
+
+        @testset "Parse hours (H)" begin
+            deadline = gRPCServer.parse_grpc_timeout("1H")
+            @test deadline !== nothing
+            # Should be approximately 1 hour from now
+            diff_ms = Dates.value(deadline - now())
+            @test diff_ms >= 3599000  # At least 59:59
+            @test diff_ms <= 3601000  # At most 1:00:01
+        end
+
+        @testset "Parse minutes (M)" begin
+            deadline = gRPCServer.parse_grpc_timeout("30M")
+            @test deadline !== nothing
+            diff_ms = Dates.value(deadline - now())
+            @test diff_ms >= 1799000  # ~30 minutes
+            @test diff_ms <= 1801000
+        end
+
+        @testset "Parse seconds (S)" begin
+            deadline = gRPCServer.parse_grpc_timeout("60S")
+            @test deadline !== nothing
+            diff_ms = Dates.value(deadline - now())
+            @test diff_ms >= 59000
+            @test diff_ms <= 61000
+        end
+
+        @testset "Parse milliseconds (m)" begin
+            deadline = gRPCServer.parse_grpc_timeout("500m")
+            @test deadline !== nothing
+            diff_ms = Dates.value(deadline - now())
+            @test diff_ms >= 490
+            @test diff_ms <= 510
+        end
+
+        @testset "Parse microseconds (u)" begin
+            deadline = gRPCServer.parse_grpc_timeout("1000u")
+            @test deadline !== nothing
+            # 1000us = 1ms
+            diff_ms = Dates.value(deadline - now())
+            @test diff_ms >= 0
+            @test diff_ms <= 10
+        end
+
+        @testset "Parse nanoseconds (n)" begin
+            deadline = gRPCServer.parse_grpc_timeout("1000000n")
+            @test deadline !== nothing
+            # 1000000ns = 1ms
+            diff_ms = Dates.value(deadline - now())
+            @test diff_ms >= 0
+            @test diff_ms <= 10
+        end
+
+        @testset "Parse zero timeout" begin
+            deadline = gRPCServer.parse_grpc_timeout("0S")
+            @test deadline !== nothing
+        end
+
+    end  # T042
+
+    # =========================================================================
+    # T043: Invalid Timeout Values
+    # =========================================================================
+
+    @testset "T043: Invalid timeout values" begin
+
+        @testset "Empty string returns nothing" begin
+            @test gRPCServer.parse_grpc_timeout("") === nothing
+        end
+
+        @testset "Missing unit returns nothing" begin
+            @test gRPCServer.parse_grpc_timeout("100") === nothing
+        end
+
+        @testset "Missing value returns nothing" begin
+            @test gRPCServer.parse_grpc_timeout("S") === nothing
+        end
+
+        @testset "Negative value returns nothing" begin
+            @test gRPCServer.parse_grpc_timeout("-1S") === nothing
+        end
+
+        @testset "Invalid unit returns nothing" begin
+            @test gRPCServer.parse_grpc_timeout("1X") === nothing
+            @test gRPCServer.parse_grpc_timeout("1s") === nothing  # lowercase
+            @test gRPCServer.parse_grpc_timeout("1h") === nothing  # lowercase
+        end
+
+        @testset "Non-numeric value returns nothing" begin
+            @test gRPCServer.parse_grpc_timeout("abcS") === nothing
+        end
+
+        @testset "Float value returns nothing" begin
+            @test gRPCServer.parse_grpc_timeout("1.5S") === nothing
+        end
+
+        @testset "All invalid test cases" begin
+            for (input, _, should_fail) in ConformanceData.TIMEOUT_TEST_CASES
+                if should_fail
+                    result = gRPCServer.parse_grpc_timeout(input)
+                    @test result === nothing
+                end
+            end
+        end
+
+    end  # T043
+
+    # =========================================================================
+    # T044: Timeout Format (output)
+    # =========================================================================
+
+    @testset "T044: Timeout format output" begin
+
+        @testset "Format hours" begin
+            deadline = now() + Hour(2)
+            formatted = gRPCServer.format_grpc_timeout(deadline)
+            @test endswith(formatted, "H")
+            value = parse(Int, formatted[1:end-1])
+            @test value >= 1 && value <= 2
+        end
+
+        @testset "Format minutes" begin
+            deadline = now() + Minute(30)
+            formatted = gRPCServer.format_grpc_timeout(deadline)
+            @test endswith(formatted, "M")
+            value = parse(Int, formatted[1:end-1])
+            @test value >= 29 && value <= 30
+        end
+
+        @testset "Format seconds" begin
+            deadline = now() + Second(45)
+            formatted = gRPCServer.format_grpc_timeout(deadline)
+            @test endswith(formatted, "S")
+            value = parse(Int, formatted[1:end-1])
+            @test value >= 44 && value <= 45
+        end
+
+        @testset "Format milliseconds" begin
+            deadline = now() + Millisecond(500)
+            formatted = gRPCServer.format_grpc_timeout(deadline)
+            @test endswith(formatted, "m")
+            value = parse(Int, formatted[1:end-1])
+            @test value >= 490 && value <= 510
+        end
+
+        @testset "Format past deadline" begin
+            deadline = now() - Second(1)
+            formatted = gRPCServer.format_grpc_timeout(deadline)
+            # Should format as 0 (past deadline)
+            @test formatted == "0m"
+        end
+
+    end  # T044
+
+    # =========================================================================
+    # T045: ServerContext Deadline
+    # =========================================================================
+
+    @testset "T045: ServerContext deadline" begin
+
+        @testset "Context with no deadline" begin
+            ctx = gRPCServer.ServerContext()
+            @test ctx.deadline === nothing
+            @test gRPCServer.remaining_time(ctx) === nothing
+        end
+
+        @testset "Context with future deadline" begin
+            future = now() + Second(60)
+            ctx = gRPCServer.ServerContext(deadline=future)
+            remaining = gRPCServer.remaining_time(ctx)
+            @test remaining !== nothing
+            @test remaining > 0
+            @test remaining <= 60.5
+        end
+
+        @testset "Context with past deadline" begin
+            past = now() - Second(5)
+            ctx = gRPCServer.ServerContext(deadline=past)
+            remaining = gRPCServer.remaining_time(ctx)
+            @test remaining !== nothing
+            @test remaining < 0
+        end
+
+        @testset "Context created from headers with timeout" begin
+            headers = [
+                (":method", "POST"),
+                (":path", "/test/Method"),
+                (":scheme", "http"),
+                (":authority", "localhost"),
+                ("content-type", "application/grpc"),
+                ("grpc-timeout", "30S"),
+            ]
+            peer = gRPCServer.PeerInfo(Sockets.IPv4("127.0.0.1"), 12345)
+            ctx = gRPCServer.create_context_from_headers(headers, peer)
+
+            @test ctx.deadline !== nothing
+            remaining = gRPCServer.remaining_time(ctx)
+            @test remaining !== nothing
+            @test remaining > 0
+            @test remaining <= 31.0
+        end
+
+    end  # T045
+
+    # =========================================================================
+    # T046: Context Cancellation
+    # =========================================================================
+
+    @testset "T046: Context cancellation" begin
+
+        @testset "Context starts not cancelled" begin
+            ctx = gRPCServer.ServerContext()
+            @test !gRPCServer.is_cancelled(ctx)
+        end
+
+        @testset "Context can be cancelled" begin
+            ctx = gRPCServer.ServerContext()
+            gRPCServer.cancel!(ctx)
+            @test gRPCServer.is_cancelled(ctx)
+        end
+
+        @testset "Cancellation is persistent" begin
+            ctx = gRPCServer.ServerContext()
+            @test !gRPCServer.is_cancelled(ctx)
+            gRPCServer.cancel!(ctx)
+            @test gRPCServer.is_cancelled(ctx)
+            @test gRPCServer.is_cancelled(ctx)  # Still cancelled
+        end
+
+    end  # T046
+
+end  # AC7: Timeout Handling


### PR DESCRIPTION
Implement comprehensive conformance testing for gRPC HTTP/2 protocol per RFC 7540 and [PROTOCOL-HTTP2.md](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md) specification.

Tests cover all 7 acceptance criteria:
- AC1: Request validation (method, content-type, path format, TE header)
- AC2: Response format (status 200, content-type, trailers)
- AC3: Message encoding (length-prefixed framing, compression)
- AC4: Custom metadata (binary base64, ASCII preservation)
- AC5: Error mapping (HTTP/2 to gRPC status codes)
- AC6: Connection management (PING/GOAWAY, flow control)
- AC7: Timeout handling (grpc-timeout parsing, deadline enforcement)

Implementation changes:
- Add message decompression support in server.jl
- Add TE header validation with warning in server.jl
- Add http2_to_grpc_status() function in errors.jl
- Fix parse_codec to accept AbstractString for SubString compatibility

New test files:
- test/fixtures/conformance_data.jl (test constants)
- test/unit/test_grpc_protocol.jl (core protocol tests)
- test/unit/test_http2_conformance.jl (HTTP/2 frame tests)
- test/unit/test_request_validation.jl (AC1)
- test/unit/test_response_format.jl (AC2)
- test/unit/test_message_encoding.jl (AC3)
- test/unit/test_custom_metadata.jl (AC4)
- test/unit/test_error_mapping.jl (AC5)
- test/unit/test_connection_management.jl (AC6)
- test/unit/test_timeout_handling.jl (AC7)